### PR TITLE
Add group overview and details pages; update trip to group

### DIFF
--- a/src/LuSplit.App/AppRoutes.cs
+++ b/src/LuSplit.App/AppRoutes.cs
@@ -2,11 +2,11 @@ namespace LuSplit.App;
 
 public static class AppRoutes
 {
-    public const string TripTimeline = "trip";
-    public const string TripDetails = "trip-details";
+    public const string GroupTimeline = "group";
+    public const string GroupDetails = "group-details";
     public const string AddEvent = "add-event";
     public const string RecordPayment = "record-payment";
     public const string Settlement = "settle-up";
     public const string LanguageSettings = "language-settings";
-    public const string ArchivedTrips = "archived-trips";
+    public const string ArchivedGroups = "archived-groups";
 }

--- a/src/LuSplit.App/AppShell.xaml
+++ b/src/LuSplit.App/AppShell.xaml
@@ -9,9 +9,9 @@
 
     <TabBar>
         <ShellContent
-            Title="{x:Static loc:AppResources.Trips_Title}"
+            Title="{x:Static loc:AppResources.Groups_Title}"
             ContentTemplate="{DataTemplate pages:HomePage}"
-            Route="trips" />
+            Route="groups" />
         <ShellContent
             Title="{x:Static loc:AppResources.Activity_Title}"
             ContentTemplate="{DataTemplate pages:ActivityPage}"

--- a/src/LuSplit.App/AppShell.xaml.cs
+++ b/src/LuSplit.App/AppShell.xaml.cs
@@ -5,13 +5,13 @@ public partial class AppShell : Shell
 	public AppShell()
 	{
 		InitializeComponent();
-		TryRegisterRoute(AppRoutes.TripTimeline, typeof(Pages.TripPage));
-		TryRegisterRoute(AppRoutes.TripDetails, typeof(Pages.TripDetailsPage));
+		TryRegisterRoute(AppRoutes.GroupTimeline, typeof(Pages.GroupPage));
+		TryRegisterRoute(AppRoutes.GroupDetails, typeof(Pages.GroupDetailsPage));
 		TryRegisterRoute(AppRoutes.AddEvent, typeof(Pages.AddExpensePage));
 		TryRegisterRoute(AppRoutes.RecordPayment, typeof(Pages.RecordPaymentPage));
 		TryRegisterRoute(AppRoutes.Settlement, typeof(Pages.SettlementPage));
 		TryRegisterRoute(AppRoutes.LanguageSettings, typeof(Pages.LanguageSettingsPage));
-		TryRegisterRoute(AppRoutes.ArchivedTrips, typeof(Pages.ArchivedTripsPage));
+		TryRegisterRoute(AppRoutes.ArchivedGroups, typeof(Pages.ArchivedGroupsPage));
 	}
 
 	// Guard against duplicate registration when the shell is rebuilt for language changes.

--- a/src/LuSplit.App/LuSplit.App.csproj
+++ b/src/LuSplit.App/LuSplit.App.csproj
@@ -83,6 +83,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Compile Update="Pages\GroupDetailsPage.xaml.cs">
+	    <DependentUpon>GroupDetailsPage.xaml</DependentUpon>
+	  </Compile>
+	  <Compile Update="Pages\GroupPage.xaml.cs">
+	    <DependentUpon>GroupPage.xaml</DependentUpon>
+	  </Compile>
+	</ItemGroup>
+
+	<ItemGroup>
 	  <MauiXaml Update="Pages\ActivityPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
@@ -92,10 +101,10 @@
 	  <MauiXaml Update="Pages\RecordPaymentPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Pages\TripDetailsPage.xaml">
+	  <MauiXaml Update="Pages\GroupDetailsPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Pages\TripPage.xaml">
+	  <MauiXaml Update="Pages\GroupPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	</ItemGroup>

--- a/src/LuSplit.App/MauiProgram.cs
+++ b/src/LuSplit.App/MauiProgram.cs
@@ -24,14 +24,14 @@ public static class MauiProgram
 		builder.Services.AddSingleton<AppDataService>();
 		builder.Services.AddTransient<AppShell>();
 		builder.Services.AddTransient<HomePage>();
-		builder.Services.AddTransient<TripPage>();
-		builder.Services.AddTransient<TripDetailsPage>();
+		builder.Services.AddTransient<GroupPage>();
+		builder.Services.AddTransient<GroupDetailsPage>();
 		builder.Services.AddTransient<ActivityPage>();
 		builder.Services.AddTransient<AddExpensePage>();
 		builder.Services.AddTransient<SettlementPage>();
 		builder.Services.AddTransient<RecordPaymentPage>();
 		builder.Services.AddTransient<LanguageSettingsPage>();
-		builder.Services.AddTransient<ArchivedTripsPage>();
+		builder.Services.AddTransient<ArchivedGroupsPage>();
 
 #if DEBUG
 		builder.Logging.AddDebug();

--- a/src/LuSplit.App/Pages/ActivityPage.xaml.cs
+++ b/src/LuSplit.App/Pages/ActivityPage.xaml.cs
@@ -30,7 +30,7 @@ public partial class ActivityPage : ContentPage
     private async Task LoadAsync()
     {
         var overview = await _dataService.GetOverviewAsync();
-        var groups = TripPresentationMapper.BuildActivity(overview);
+        var groups = GroupPresentationMapper.BuildActivity(overview);
 
         ActivityGroups.Clear();
         foreach (var group in groups)

--- a/src/LuSplit.App/Pages/ArchivedTripsPage.xaml
+++ b/src/LuSplit.App/Pages/ArchivedTripsPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:admob="clr-namespace:Plugin.MauiMtAdmob.Controls;assembly=Plugin.MauiMtAdmob"
              xmlns:loc="clr-namespace:LuSplit.App.Resources.Localization"
-             x:Class="LuSplit.App.Pages.ArchivedTripsPage"
+             x:Class="LuSplit.App.Pages.ArchivedGroupsPage"
              Title="{x:Static loc:AppResources.Archived_Title}">
     <Grid RowDefinitions="*,Auto">
 
@@ -14,7 +14,7 @@
                     <Label Text="{x:Static loc:AppResources.Archived_Subtitle}" Style="{StaticResource BodyMuted}" />
                 </VerticalStackLayout>
 
-                <CollectionView ItemsSource="{Binding Trips}" SelectionMode="None">
+                <CollectionView ItemsSource="{Binding Groups}" SelectionMode="None">
                     <CollectionView.EmptyView>
                         <VerticalStackLayout Padding="0,24,0,0" Spacing="8">
                             <Label Text="{x:Static loc:AppResources.Archived_EmptyTitle}"
@@ -44,9 +44,9 @@
                                             </Border>
                                         </VerticalStackLayout>
                                     </Grid>
-                                    <Button Text="{x:Static loc:AppResources.Trips_Open}"
+                                    <Button Text="{x:Static loc:AppResources.Groups_Open}"
                                             Style="{StaticResource SecondaryButton}"
-                                            Clicked="OnViewTripClicked"
+                                            Clicked="OnViewGroupClicked"
                                             CommandParameter="{Binding GroupId}" />
                                 </VerticalStackLayout>
                             </Border>

--- a/src/LuSplit.App/Pages/ArchivedTripsPage.xaml.cs
+++ b/src/LuSplit.App/Pages/ArchivedTripsPage.xaml.cs
@@ -3,13 +3,13 @@ using LuSplit.App.Services;
 
 namespace LuSplit.App.Pages;
 
-public partial class ArchivedTripsPage : ContentPage
+public partial class ArchivedGroupsPage : ContentPage
 {
     private readonly AppDataService _dataService;
 
-    public ObservableCollection<TripListItemModel> Trips { get; } = new();
+    public ObservableCollection<GroupListItemModel> Groups { get; } = new();
 
-    public ArchivedTripsPage(AppDataService dataService)
+    public ArchivedGroupsPage(AppDataService dataService)
     {
         _dataService = dataService;
 
@@ -30,11 +30,11 @@ public partial class ArchivedTripsPage : ContentPage
 
     private async Task LoadAsync()
     {
-        var trips = await _dataService.GetArchivedTripsAsync();
+        var groups = await _dataService.GetArchivedGroupsAsync();
 
-        Trips.Clear();
-        foreach (var trip in trips)
-            Trips.Add(trip);
+        Groups.Clear();
+        foreach (var group in groups)
+            Groups.Add(group);
     }
 
     private async void OnDataChanged(object? sender, EventArgs e)
@@ -42,14 +42,14 @@ public partial class ArchivedTripsPage : ContentPage
         await MainThread.InvokeOnMainThreadAsync(LoadAsync);
     }
 
-    // Navigate to the trip timeline in read-only (archived) mode.
-    // We pass the groupId as a query param so TripPage loads that specific trip
-    // WITHOUT changing the user's currently selected active trip.
-    private async void OnViewTripClicked(object? sender, EventArgs e)
+    // Navigate to the group timeline in read-only (archived) mode.
+    // We pass the groupId as a query param so GroupPage loads that specific group
+    // WITHOUT changing the user's currently selected active group.
+    private async void OnViewGroupClicked(object? sender, EventArgs e)
     {
         if (sender is Button { CommandParameter: string groupId } && !string.IsNullOrWhiteSpace(groupId))
         {
-            await Shell.Current.GoToAsync($"{AppRoutes.TripTimeline}?groupId={Uri.EscapeDataString(groupId)}");
+            await Shell.Current.GoToAsync($"{AppRoutes.GroupTimeline}?groupId={Uri.EscapeDataString(groupId)}");
         }
     }
 }

--- a/src/LuSplit.App/Pages/GroupDetailsPage.xaml
+++ b/src/LuSplit.App/Pages/GroupDetailsPage.xaml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="LuSplit.App.Pages.TripDetailsPage"
+             x:Class="LuSplit.App.Pages.GroupDetailsPage"
              xmlns:admob="clr-namespace:Plugin.MauiMtAdmob.Controls;assembly=Plugin.MauiMtAdmob"
              xmlns:loc="clr-namespace:LuSplit.App.Resources.Localization"
-             Title="{x:Static loc:AppResources.TripDetails_Title}">
+             Title="{x:Static loc:AppResources.GroupDetails_Title}">
     <Grid RowDefinitions="*,Auto">
         <ScrollView>
             <VerticalStackLayout Padding="8,8,8,8" Spacing="14">
                 <Label Text="{Binding PageTitle}" Style="{StaticResource DisplayTitle}" />
                 <Label Text="{Binding PageSubtitle}" Style="{StaticResource BodyMuted}" />
 
-                <!-- Archived trip banner -->
+                <!-- Archived group banner -->
                 <Border IsVisible="{Binding IsArchived}"
                         BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
                         StrokeThickness="1"
                         StrokeShape="RoundRectangle 10"
                         Padding="12,8">
-                    <Label Text="{x:Static loc:AppResources.TripDetails_ArchivedStatus}"
+                    <Label Text="{x:Static loc:AppResources.GroupDetails_ArchivedStatus}"
                            Style="{StaticResource BodyMuted}"
                            HorizontalTextAlignment="Center" />
                 </Border>
 
                 <Border Style="{StaticResource FormFieldBorder}">
                     <VerticalStackLayout Spacing="6">
-                        <Label Text="{x:Static loc:AppResources.TripDetails_TripNameLabel}" Style="{StaticResource FieldLabel}" />
-                        <Entry Text="{Binding TripName}" Placeholder="{x:Static loc:AppResources.TripDetails_TripNamePlaceholder}" ClearButtonVisibility="WhileEditing" />
+                        <Label Text="{x:Static loc:AppResources.GroupDetails_GroupNameLabel}" Style="{StaticResource FieldLabel}" />
+                        <Entry Text="{Binding GroupName}" Placeholder="{x:Static loc:AppResources.GroupDetails_GroupNamePlaceholder}" ClearButtonVisibility="WhileEditing" />
                     </VerticalStackLayout>
                 </Border>
 
                 <Border Style="{StaticResource FormFieldBorder}">
                     <VerticalStackLayout Spacing="6">
-                        <Label Text="{x:Static loc:AppResources.TripDetails_CurrencyLabel}" Style="{StaticResource FieldLabel}" />
+                        <Label Text="{x:Static loc:AppResources.GroupDetails_CurrencyLabel}" Style="{StaticResource FieldLabel}" />
                         <Picker ItemsSource="{Binding CurrencyOptions}" SelectedItem="{Binding SelectedCurrency}" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Label Text="{x:Static loc:AppResources.TripDetails_PeopleSection}" Style="{StaticResource SectionTitle}" />
-                <Label Text="{x:Static loc:AppResources.TripDetails_HouseholdHint}" Style="{StaticResource BodyMuted}" />
+                <Label Text="{x:Static loc:AppResources.GroupDetails_PeopleSection}" Style="{StaticResource SectionTitle}" />
+                <Label Text="{x:Static loc:AppResources.GroupDetails_HouseholdHint}" Style="{StaticResource BodyMuted}" />
 
                 <CollectionView ItemsSource="{Binding People}" SelectionMode="None">
                     <CollectionView.EmptyView>
                         <VerticalStackLayout Padding="0,8,0,0" Spacing="8">
-                            <Label Text="{x:Static loc:AppResources.TripDetails_NoPeopleTitle}" Style="{StaticResource SectionTitle}" HorizontalTextAlignment="Center" />
-                            <Label Text="{x:Static loc:AppResources.TripDetails_NoPeopleSubtitle}" Style="{StaticResource BodyMuted}" HorizontalTextAlignment="Center" />
+                            <Label Text="{x:Static loc:AppResources.GroupDetails_NoPeopleTitle}" Style="{StaticResource SectionTitle}" HorizontalTextAlignment="Center" />
+                            <Label Text="{x:Static loc:AppResources.GroupDetails_NoPeopleSubtitle}" Style="{StaticResource BodyMuted}" HorizontalTextAlignment="Center" />
                         </VerticalStackLayout>
                     </CollectionView.EmptyView>
                     <CollectionView.ItemTemplate>
@@ -59,7 +59,7 @@
                                     </VerticalStackLayout>
                                     <Button Grid.Column="1"
                                         IsVisible="{Binding CanRemove}"
-                                        Text="{x:Static loc:AppResources.TripDetails_Remove}"
+                                        Text="{x:Static loc:AppResources.GroupDetails_Remove}"
                                         Clicked="OnRemovePersonClicked"
                                         CommandParameter="{Binding Name}" />
                                 </Grid>
@@ -68,36 +68,37 @@
                     </CollectionView.ItemTemplate>
                 </CollectionView>
 
-                <!-- Add person section (hidden for archived trips) -->
+                <!-- Add person section (hidden for archived groups) -->
                 <Border Style="{StaticResource FormFieldBorder}" IsVisible="{Binding CanEdit}">
                     <VerticalStackLayout Spacing="12">
-                        <Label Text="{x:Static loc:AppResources.TripDetails_AddPersonSection}" Style="{StaticResource SectionTitle}" />
-                        <Label Text="{x:Static loc:AppResources.TripDetails_AddPersonHint}" Style="{StaticResource BodyMuted}" />
-                        <Entry Text="{Binding NewPersonName}" Placeholder="{x:Static loc:AppResources.TripDetails_PersonNamePlaceholder}" ClearButtonVisibility="WhileEditing" />
-                        <Entry Text="{Binding NewHouseholdName}" Placeholder="{x:Static loc:AppResources.TripDetails_HouseholdNamePlaceholder}" ClearButtonVisibility="WhileEditing" />
-                        <Label Text="{x:Static loc:AppResources.TripDetails_ConsumptionCategoryLabel}" Style="{StaticResource FieldLabel}" />
+                        <Label Text="{x:Static loc:AppResources.GroupDetails_AddPersonSection}" Style="{StaticResource SectionTitle}" />
+                        <Label Text="{x:Static loc:AppResources.GroupDetails_AddPersonHint}" Style="{StaticResource BodyMuted}" />
+                        <Entry Text="{Binding NewPersonName}" Placeholder="{x:Static loc:AppResources.GroupDetails_PersonNamePlaceholder}" ClearButtonVisibility="WhileEditing" />
+                        <Entry Text="{Binding NewHouseholdName}" Placeholder="{x:Static loc:AppResources.GroupDetails_HouseholdNamePlaceholder}" ClearButtonVisibility="WhileEditing" />
+                        <Label Text="{x:Static loc:AppResources.GroupDetails_ConsumptionCategoryLabel}" Style="{StaticResource FieldLabel}" />
                         <Picker ItemsSource="{Binding ConsumptionOptions}"
-                                SelectedItem="{Binding SelectedConsumptionOption}" />
+                                SelectedItem="{Binding SelectedConsumption}"
+                                ItemDisplayBinding="{Binding Label}" />
                         <Entry Text="{Binding NewCustomWeight}"
-                               Placeholder="{x:Static loc:AppResources.TripDetails_CustomWeightPlaceholder}"
+                               Placeholder="{x:Static loc:AppResources.GroupDetails_CustomWeightPlaceholder}"
                                Keyboard="Numeric"
                                IsVisible="{Binding IsCustomConsumption}"
                                ClearButtonVisibility="WhileEditing" />
-                        <Button Text="{x:Static loc:AppResources.TripDetails_AddPersonButton}" Clicked="OnAddPersonClicked" />
+                        <Button Text="{x:Static loc:AppResources.GroupDetails_AddPersonButton}" Clicked="OnAddPersonClicked" />
                     </VerticalStackLayout>
                 </Border>
 
-                <!-- Save / create button (hidden for archived trips) -->
+                <!-- Save / create button (hidden for archived groups) -->
                 <Button Text="{Binding SaveButtonText}" IsVisible="{Binding CanEdit}" Clicked="OnSaveClicked" />
 
-                <Button Text="{x:Static loc:AppResources.TripDetails_ExportButton}"
+                <Button Text="{x:Static loc:AppResources.GroupDetails_ExportButton}"
                         IsVisible="{Binding CanExport}"
                         Style="{StaticResource SecondaryButton}"
                         Margin="0,4,0,0"
                         Clicked="OnExportClicked" />
 
-                <!-- Archive button: only visible for active (non-archived) edit-mode trips -->
-                <Button Text="{x:Static loc:AppResources.TripDetails_ArchiveButton}"
+                <!-- Archive button: only visible for active (non-archived) edit-mode groups -->
+                <Button Text="{x:Static loc:AppResources.GroupDetails_ArchiveButton}"
                         IsVisible="{Binding CanArchive}"
                         Style="{StaticResource SecondaryButton}"
                         Margin="0,0,0,0"

--- a/src/LuSplit.App/Pages/GroupDetailsPage.xaml.cs
+++ b/src/LuSplit.App/Pages/GroupDetailsPage.xaml.cs
@@ -3,17 +3,16 @@ using LuSplit.App.Resources.Localization;
 using LuSplit.App.Services;
 using LuSplit.Application.Models;
 using LuSplit.Domain.Entities;
-using Microsoft.Maui.ApplicationModel.DataTransfer;
 
 namespace LuSplit.App.Pages;
 
-public partial class TripDetailsPage : ContentPage, IQueryAttributable
+public partial class GroupDetailsPage : ContentPage, IQueryAttributable
 {
     private readonly AppDataService _dataService;
     private string _mode = EditMode;
     private string? _groupId;
-    // Set when navigating from an archived trip view, to load a specific group
-    // without changing the user's currently selected active trip.
+    // Set when navigating from an archived group view, to load a specific group
+    // without changing the user's currently selected active group.
     private string? _overrideGroupId;
     private bool _isArchived;
 
@@ -22,17 +21,14 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
 
     public ObservableCollection<string> CurrencyOptions { get; } = new() { "USD", "EUR", "GBP" };
 
-    public ObservableCollection<TripPersonEditorViewModel> People { get; } = new();
+    public ObservableCollection<GroupPersonEditorViewModel> People { get; } = new();
 
     // Consumption category options shown in the Add Person picker.
-    public ObservableCollection<string> ConsumptionOptions { get; } = new()
-    {
-        AppResources.TripDetails_ConsumptionFull,
-        AppResources.TripDetails_ConsumptionHalf,
-        AppResources.TripDetails_ConsumptionCustom
-    };
+    // Using an enum-backed view model so the picker comparison is stable
+    // regardless of the active locale — avoids comparing localized strings.
+    public ObservableCollection<ConsumptionOptionViewModel> ConsumptionOptions { get; }
 
-    public string TripName { get; set; } = string.Empty;
+    public string GroupName { get; set; } = string.Empty;
 
     public string? SelectedCurrency { get; set; } = "USD";
 
@@ -40,7 +36,7 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
 
     public string NewHouseholdName { get; set; } = string.Empty;
 
-    public string SelectedConsumptionOption { get; set; } = AppResources.TripDetails_ConsumptionFull;
+    public ConsumptionOptionViewModel SelectedConsumption { get; set; }
 
     public string NewCustomWeight { get; set; } = string.Empty;
 
@@ -48,7 +44,7 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
 
     public bool IsArchived => _isArchived;
 
-    /// <summary>True when the trip can be edited — i.e. it is not archived.</summary>
+    /// <summary>True when the group can be edited — i.e. it is not archived.</summary>
     public bool CanEdit => !IsCreateMode && !_isArchived;
 
     public bool CanExport => !IsCreateMode;
@@ -57,22 +53,28 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
     public bool CanArchive => !IsCreateMode && !_isArchived;
 
     /// <summary>Custom-weight entry is visible only when "Custom weight" is selected.</summary>
-    public bool IsCustomConsumption =>
-        string.Equals(SelectedConsumptionOption, AppResources.TripDetails_ConsumptionCustom, StringComparison.Ordinal);
+    public bool IsCustomConsumption => SelectedConsumption?.Category == ConsumptionCategory.Custom;
 
-    public string PageTitle => IsCreateMode ? AppResources.TripDetails_PageTitleCreate : AppResources.TripDetails_PageTitleEdit;
+    public string PageTitle => IsCreateMode ? AppResources.GroupDetails_PageTitleCreate : AppResources.GroupDetails_PageTitleEdit;
 
     public string PageSubtitle => IsCreateMode
-        ? AppResources.TripDetails_SubtitleCreate
-        : (_isArchived ? AppResources.TripDetails_ArchivedStatus : AppResources.TripDetails_SubtitleEdit);
+        ? AppResources.GroupDetails_SubtitleCreate
+        : (_isArchived ? AppResources.GroupDetails_ArchivedStatus : AppResources.GroupDetails_SubtitleEdit);
 
-    public string SaveButtonText => IsCreateMode ? AppResources.TripDetails_CreateButton : AppResources.TripDetails_SaveButton;
+    public string SaveButtonText => IsCreateMode ? AppResources.GroupDetails_CreateButton : AppResources.GroupDetails_SaveButton;
 
     private bool IsCreateMode => string.Equals(_mode, CreateMode, StringComparison.OrdinalIgnoreCase);
 
-    public TripDetailsPage(AppDataService dataService)
+    public GroupDetailsPage(AppDataService dataService)
     {
         _dataService = dataService;
+        ConsumptionOptions = new()
+        {
+            new(ConsumptionCategory.Full, AppResources.GroupDetails_ConsumptionFull),
+            new(ConsumptionCategory.Half, AppResources.GroupDetails_ConsumptionHalf),
+            new(ConsumptionCategory.Custom, AppResources.GroupDetails_ConsumptionCustom),
+        };
+        SelectedConsumption = ConsumptionOptions[0];
         InitializeComponent();
         BindingContext = this;
 #if ANDROID
@@ -105,26 +107,26 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
         if (IsCreateMode)
         {
             _groupId = null;
-            TripName = string.Empty;
+            GroupName = string.Empty;
             SelectedCurrency = SelectedCurrency is null ? "USD" : SelectedCurrency;
             People.Clear();
         }
         else
         {
             var details = _overrideGroupId is not null
-                ? await _dataService.GetTripDetailsAsync(_overrideGroupId)
-                : await _dataService.GetTripDetailsAsync();
+                ? await _dataService.GetGroupDetailsAsync(_overrideGroupId)
+                : await _dataService.GetGroupDetailsAsync();
 
             _groupId = details.GroupId;
             _isArchived = details.IsArchived;
-            TripName = details.TripName;
+            GroupName = details.GroupName;
             EnsureCurrencyOption(details.Currency);
             SelectedCurrency = details.Currency;
 
             People.Clear();
             foreach (var person in details.Members)
             {
-                People.Add(new TripPersonEditorViewModel(
+                People.Add(new GroupPersonEditorViewModel(
                     person.Name,
                     person.HouseholdName,
                     false,
@@ -136,7 +138,7 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
 
         NewPersonName = string.Empty;
         NewHouseholdName = string.Empty;
-        SelectedConsumptionOption = AppResources.TripDetails_ConsumptionFull;
+        SelectedConsumption = ConsumptionOptions[0];
         NewCustomWeight = string.Empty;
         Title = PageTitle;
 
@@ -168,9 +170,9 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
 
             if (IsCreateMode)
             {
-                People.Add(new TripPersonEditorViewModel(
+                People.Add(new GroupPersonEditorViewModel(
                     NewPersonName.Trim(),
-                    string.IsNullOrWhiteSpace(NewHouseholdName) ? AppResources.TripDetails_SettlesOnOwn : NewHouseholdName.Trim(),
+                    string.IsNullOrWhiteSpace(NewHouseholdName) ? null : NewHouseholdName.Trim(),
                     true,
                     false,
                     CategoryToString(category),
@@ -180,26 +182,26 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
             {
                 if (string.IsNullOrWhiteSpace(_groupId))
                 {
-                    StatusText = AppResources.Validation_TripNotFound;
+                    StatusText = AppResources.Validation_GroupNotFound;
                     OnPropertyChanged(nameof(StatusText));
                     return;
                 }
 
-                await _dataService.AddTripMemberAsync(
+                await _dataService.AddGroupMemberAsync(
                     _groupId,
                     NewPersonName,
                     NewHouseholdName,
                     category,
                     category == ConsumptionCategory.Custom ? NewCustomWeight.Trim() : null);
-                StatusText = AppResources.TripDetails_PersonAdded;
+                StatusText = AppResources.GroupDetails_PersonAdded;
                 await LoadAsync();
             }
 
             NewPersonName = string.Empty;
             NewHouseholdName = string.Empty;
-            SelectedConsumptionOption = AppResources.TripDetails_ConsumptionFull;
+            SelectedConsumption = ConsumptionOptions[0];
             NewCustomWeight = string.Empty;
-            StatusText = IsCreateMode ? AppResources.TripDetails_PersonAddedNew : StatusText;
+            StatusText = IsCreateMode ? AppResources.GroupDetails_PersonAddedNew : StatusText;
             NotifyAddPersonProperties();
         }
         catch (Exception ex)
@@ -227,9 +229,9 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
     {
         try
         {
-            if (string.IsNullOrWhiteSpace(TripName))
+            if (string.IsNullOrWhiteSpace(GroupName))
             {
-                StatusText = AppResources.Validation_TripNameRequired;
+                StatusText = AppResources.Validation_GroupNameRequired;
                 OnPropertyChanged(nameof(StatusText));
                 return;
             }
@@ -250,30 +252,28 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
                     return;
                 }
 
-                await _dataService.CreateTripAsync(
-                    TripName,
+                await _dataService.CreateGroupAsync(
+                    GroupName,
                     SelectedCurrency,
-                    People.Select(person => new TripDraftMember(
+                    People.Select(person => new GroupDraftMember(
                         person.Name,
-                        string.Equals(person.HouseholdText, AppResources.TripDetails_SettlesOnOwn, StringComparison.Ordinal)
-                            ? null
-                            : person.HouseholdText,
+                        string.IsNullOrEmpty(person.HouseholdName) ? null : person.HouseholdName,
                         StringToCategory(person.ConsumptionCategory),
                         person.CustomConsumptionWeight)).ToArray());
 
-                await Shell.Current.GoToAsync("//trips");
-                await Shell.Current.GoToAsync(AppRoutes.TripTimeline);
+                await Shell.Current.GoToAsync("//groups");
+                await Shell.Current.GoToAsync(AppRoutes.GroupTimeline);
             }
             else
             {
                 if (string.IsNullOrWhiteSpace(_groupId))
                 {
-                    StatusText = AppResources.Validation_TripNotFound;
+                    StatusText = AppResources.Validation_GroupNotFound;
                     OnPropertyChanged(nameof(StatusText));
                     return;
                 }
 
-                await _dataService.UpdateTripAsync(_groupId, TripName, SelectedCurrency);
+                await _dataService.UpdateGroupAsync(_groupId, GroupName, SelectedCurrency);
                 await Shell.Current.GoToAsync("..");
             }
         }
@@ -288,18 +288,18 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
     {
         if (string.IsNullOrWhiteSpace(_groupId)) return;
 
-        var confirmed = await DisplayAlert(
-            AppResources.TripDetails_ArchiveConfirmTitle,
-            AppResources.TripDetails_ArchiveConfirmMessage,
-            AppResources.TripDetails_ArchiveConfirmYes,
+        var confirmed = await DisplayAlertAsync(
+            AppResources.GroupDetails_ArchiveConfirmTitle,
+            AppResources.GroupDetails_ArchiveConfirmMessage,
+            AppResources.GroupDetails_ArchiveConfirmYes,
             AppResources.Common_Cancel);
 
         if (!confirmed) return;
 
         try
         {
-            await _dataService.ArchiveTripAsync(_groupId);
-            await Shell.Current.GoToAsync("//trips");
+            await _dataService.ArchiveGroupAsync(_groupId);
+            await Shell.Current.GoToAsync("//groups");
         }
         catch (Exception ex)
         {
@@ -320,26 +320,27 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
     {
         if (_groupId is null) return;
 
-        var choice = await DisplayActionSheet(
+        var exportOptions = new (string Label, ExportFormat Format)[]
+        {
+            (AppResources.Export_JsonOption, ExportFormat.Json),
+            (AppResources.Export_CsvOption, ExportFormat.Csv),
+            (AppResources.Export_PdfOption, ExportFormat.Pdf),
+        };
+
+        var choice = await DisplayActionSheetAsync(
             AppResources.Export_DialogTitle,
             AppResources.Common_Cancel,
             null,
-            AppResources.Export_JsonOption,
-            AppResources.Export_CsvOption,
-            AppResources.Export_PdfOption);
+            exportOptions.Select(o => o.Label).ToArray());
 
         if (string.IsNullOrEmpty(choice) || choice == AppResources.Common_Cancel) return;
 
-        ExportFormat? format = null;
-        if (choice == AppResources.Export_JsonOption) format = ExportFormat.Json;
-        else if (choice == AppResources.Export_CsvOption) format = ExportFormat.Csv;
-        else if (choice == AppResources.Export_PdfOption) format = ExportFormat.Pdf;
-
-        if (format is null) return;
+        var selected = Array.Find(exportOptions, o => string.Equals(o.Label, choice, StringComparison.Ordinal));
+        if (selected.Label is null) return;
 
         try
         {
-            var result = await _dataService.ExportTripAsync(_groupId, format.Value);
+            var result = await _dataService.ExportGroupAsync(_groupId, selected.Format);
             await Share.RequestAsync(new ShareFileRequest
             {
                 Title = AppResources.Export_ShareTitle,
@@ -354,13 +355,7 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
     }
 
     private ConsumptionCategory ResolveConsumptionCategory()
-    {
-        if (string.Equals(SelectedConsumptionOption, AppResources.TripDetails_ConsumptionHalf, StringComparison.Ordinal))
-            return ConsumptionCategory.Half;
-        if (string.Equals(SelectedConsumptionOption, AppResources.TripDetails_ConsumptionCustom, StringComparison.Ordinal))
-            return ConsumptionCategory.Custom;
-        return ConsumptionCategory.Full;
-    }
+        => SelectedConsumption?.Category ?? ConsumptionCategory.Full;
 
     private static string CategoryToString(ConsumptionCategory category)
         => category switch
@@ -380,7 +375,7 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
 
     private void NotifyAllProperties()
     {
-        OnPropertyChanged(nameof(TripName));
+        OnPropertyChanged(nameof(GroupName));
         OnPropertyChanged(nameof(SelectedCurrency));
         OnPropertyChanged(nameof(IsArchived));
         OnPropertyChanged(nameof(CanEdit));
@@ -397,16 +392,16 @@ public partial class TripDetailsPage : ContentPage, IQueryAttributable
     {
         OnPropertyChanged(nameof(NewPersonName));
         OnPropertyChanged(nameof(NewHouseholdName));
-        OnPropertyChanged(nameof(SelectedConsumptionOption));
+        OnPropertyChanged(nameof(SelectedConsumption));
         OnPropertyChanged(nameof(NewCustomWeight));
         OnPropertyChanged(nameof(IsCustomConsumption));
         OnPropertyChanged(nameof(StatusText));
     }
 }
 
-public sealed record TripPersonEditorViewModel(
+public sealed record GroupPersonEditorViewModel(
     string Name,
-    string HouseholdText,
+    string? HouseholdName,  // null or empty means "settles on own" — avoids localized-string comparison
     bool CanRemove,
     bool IsOwner = false,
     string ConsumptionCategory = "FULL",
@@ -417,13 +412,24 @@ public sealed record TripPersonEditorViewModel(
     public bool ShowRoleBadge => !CanRemove;
 
     public string RoleBadge => IsOwner
-        ? AppResources.TripDetails_PersonIsOwner
-        : AppResources.TripDetails_PersonIsDependent;
+        ? AppResources.GroupDetails_PersonIsOwner
+        : AppResources.GroupDetails_PersonIsDependent;
+
+    /// <summary>Display text for the household column. Falls back to the localized "Settles on their own" sentinel when no household name is set.</summary>
+    public string HouseholdText => string.IsNullOrEmpty(HouseholdName)
+        ? AppResources.GroupDetails_SettlesOnOwn
+        : HouseholdName;
 
     public string ConsumptionLabel => ConsumptionCategory switch
     {
-        "HALF" => AppResources.TripDetails_ConsumptionHalf,
-        "CUSTOM" => $"{AppResources.TripDetails_ConsumptionCustom}: {CustomConsumptionWeight}",
-        _ => AppResources.TripDetails_ConsumptionFull
+        "HALF" => AppResources.GroupDetails_ConsumptionHalf,
+        "CUSTOM" => $"{AppResources.GroupDetails_ConsumptionCustom}: {CustomConsumptionWeight}",
+        _ => AppResources.GroupDetails_ConsumptionFull
     };
 }
+
+/// <summary>
+/// Stable enum-backed option for the consumption category picker.
+/// Using <see cref="Category"/> for comparisons avoids binding to localized labels.
+/// </summary>
+public sealed record ConsumptionOptionViewModel(ConsumptionCategory Category, string Label);

--- a/src/LuSplit.App/Pages/GroupPage.xaml
+++ b/src/LuSplit.App/Pages/GroupPage.xaml
@@ -2,43 +2,43 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:loc="clr-namespace:LuSplit.App.Resources.Localization"
-             x:Class="LuSplit.App.Pages.TripPage"
+             x:Class="LuSplit.App.Pages.GroupPage"
              xmlns:admob="clr-namespace:Plugin.MauiMtAdmob.Controls;assembly=Plugin.MauiMtAdmob"
-             Title="{x:Static loc:AppResources.Trip_Title}">
+             Title="{x:Static loc:AppResources.Group_Title}">
 
     <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{x:Static loc:AppResources.Trip_DetailsButton}" Clicked="OnTripDetailsClicked" />
+        <ToolbarItem Text="{x:Static loc:AppResources.Group_DetailsButton}" Clicked="OnGroupDetailsClicked" />
     </ContentPage.ToolbarItems>
 
     <Grid RowDefinitions="*,Auto">
         <ScrollView>
             <VerticalStackLayout Padding="20,16,20,24" Spacing="16">
 
-                <!-- Archived trip banner (hidden for active trips) -->
+                <!-- Archived group banner (hidden for active groups) -->
                 <Border IsVisible="{Binding IsArchived}"
                         BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
                         StrokeThickness="1"
                         StrokeShape="RoundRectangle 10"
                         Padding="12,8">
-                    <Label Text="{x:Static loc:AppResources.TripDetails_ArchivedStatus}"
+                    <Label Text="{x:Static loc:AppResources.GroupDetails_ArchivedStatus}"
                            Style="{StaticResource BodyMuted}"
                            HorizontalTextAlignment="Center" />
                 </Border>
 
-                <!-- Trip header -->
+                <!-- Group header -->
                 <VerticalStackLayout Spacing="4">
-                    <Label Text="{Binding TripName}" Style="{StaticResource DisplayTitle}" />
-                    <Label Text="{Binding TripSummaryText}" Style="{StaticResource BodyMuted}" />
+                    <Label Text="{Binding GroupName}" Style="{StaticResource DisplayTitle}" />
+                    <Label Text="{Binding GroupSummaryText}" Style="{StaticResource BodyMuted}" />
                 </VerticalStackLayout>
 
                 <!-- Balance summary card -->
                 <Border Style="{StaticResource ExpenseItemBorder}">
                     <VerticalStackLayout Spacing="12">
-                        <Label Text="{x:Static loc:AppResources.Trip_WhoOwesWhat}" Style="{StaticResource SectionTitle}" />
+                        <Label Text="{x:Static loc:AppResources.Group_WhoOwesWhat}" Style="{StaticResource SectionTitle}" />
                         <CollectionView ItemsSource="{Binding BalanceLines}"
                                         SelectionMode="None">
                             <CollectionView.EmptyView>
-                                <Label Text="{x:Static loc:AppResources.Trip_EveryoneEven}" Style="{StaticResource BodyText}" />
+                                <Label Text="{x:Static loc:AppResources.Group_EveryoneEven}" Style="{StaticResource BodyText}" />
                             </CollectionView.EmptyView>
                             <CollectionView.ItemTemplate>
                                 <DataTemplate>
@@ -52,7 +52,7 @@
                                 </DataTemplate>
                             </CollectionView.ItemTemplate>
                         </CollectionView>
-                        <Button Text="{x:Static loc:AppResources.Trip_SettleUp}"
+                        <Button Text="{x:Static loc:AppResources.Group_SettleUp}"
                                 Style="{StaticResource SecondaryButton}"
                                 HorizontalOptions="Start"
                                 Clicked="OnSettleUpClicked" />
@@ -60,16 +60,16 @@
                 </Border>
 
                 <!-- Events section -->
-                <Label Text="{x:Static loc:AppResources.Trip_Events}" Style="{StaticResource SectionTitle}" Margin="0,4,0,0" />
+                <Label Text="{x:Static loc:AppResources.Group_Events}" Style="{StaticResource SectionTitle}" Margin="0,4,0,0" />
 
                 <CollectionView ItemsSource="{Binding TimelineItems}"
                                 SelectionMode="None">
                     <CollectionView.EmptyView>
                         <VerticalStackLayout Padding="0,16,0,0" Spacing="8">
-                            <Label Text="{x:Static loc:AppResources.Trip_EmptyTitle}"
+                            <Label Text="{x:Static loc:AppResources.Group_EmptyTitle}"
                                    Style="{StaticResource SectionTitle}"
                                    HorizontalTextAlignment="Center" />
-                            <Label Text="{x:Static loc:AppResources.Trip_EmptySubtitle}"
+                            <Label Text="{x:Static loc:AppResources.Group_EmptySubtitle}"
                                    Style="{StaticResource BodyMuted}"
                                    HorizontalTextAlignment="Center" />
                         </VerticalStackLayout>
@@ -93,12 +93,12 @@
                     </CollectionView.ItemTemplate>
                 </CollectionView>
 
-                <!-- Quick actions (hidden for archived trips) -->
+                <!-- Quick actions (hidden for archived groups) -->
                 <Grid ColumnDefinitions="*,*" ColumnSpacing="12" Margin="0,4,0,0"
                       IsVisible="{Binding CanEdit}">
-                    <Button Grid.Column="0" Text="{x:Static loc:AppResources.Trip_AddExpense}" Clicked="OnAddEventClicked" />
+                    <Button Grid.Column="0" Text="{x:Static loc:AppResources.Group_AddExpense}" Clicked="OnAddEventClicked" />
                     <Button Grid.Column="1"
-                            Text="{x:Static loc:AppResources.Trip_RecordPayment}"
+                            Text="{x:Static loc:AppResources.Group_RecordPayment}"
                             Style="{StaticResource SecondaryButton}"
                             Clicked="OnRecordPaymentClicked" />
                 </Grid>

--- a/src/LuSplit.App/Pages/GroupPage.xaml.cs
+++ b/src/LuSplit.App/Pages/GroupPage.xaml.cs
@@ -4,26 +4,26 @@ using LuSplit.Application.Models;
 
 namespace LuSplit.App.Pages;
 
-public partial class TripPage : ContentPage, IQueryAttributable
+public partial class GroupPage : ContentPage, IQueryAttributable
 {
     private readonly AppDataService _dataService;
-    // Set when navigating to this page for a specific (e.g. archived) trip,
-    // without changing the user's currently selected active trip.
+    // Set when navigating to this page for a specific (e.g. archived) group,
+    // without changing the user's currently selected active group.
     private string? _overrideGroupId;
 
     public ObservableCollection<TimelineEntryViewModel> TimelineItems { get; } = new();
 
     public ObservableCollection<BalanceLineViewModel> BalanceLines { get; } = new();
 
-    public string TripName { get; private set; } = "Trip";
+    public string GroupName { get; private set; } = string.Empty;
 
-    public string TripSummaryText { get; private set; } = string.Empty;
+    public string GroupSummaryText { get; private set; } = string.Empty;
 
     public bool IsArchived { get; private set; }
 
     public bool CanEdit => !IsArchived;
 
-    public TripPage(AppDataService dataService)
+    public GroupPage(AppDataService dataService)
     {
         _dataService = dataService;
 
@@ -52,47 +52,47 @@ public partial class TripPage : ContentPage, IQueryAttributable
     private async Task LoadAsync()
     {
         var workspace = _overrideGroupId is not null
-            ? await _dataService.GetTripWorkspaceAsync(_overrideGroupId)
-            : await _dataService.GetTripWorkspaceAsync();
+            ? await _dataService.GetGroupWorkspaceAsync(_overrideGroupId)
+            : await _dataService.GetGroupWorkspaceAsync();
 
-        TripName = workspace.TripName;
-        TripSummaryText = TripPresentationMapper.BuildTripSummary(workspace.Overview);
+        GroupName = workspace.GroupName;
+        GroupSummaryText = GroupPresentationMapper.BuildGroupSummary(workspace.Overview);
         IsArchived = workspace.Overview.Group.Closed;
-        Title = workspace.TripName;
+        Title = workspace.GroupName;
 
         TimelineItems.Clear();
-        foreach (var item in TripPresentationMapper.BuildTimeline(workspace.Overview, workspace.ExpenseIcons))
+        foreach (var item in GroupPresentationMapper.BuildTimeline(workspace.Overview, workspace.ExpenseIcons))
             TimelineItems.Add(item);
 
         BalanceLines.Clear();
-        var settlementMode = TripPresentationMapper.ResolveSettlementMode(workspace.Overview);
-        foreach (var line in TripPresentationMapper.BuildWhoOwesWho(workspace.Overview, settlementMode))
+        var settlementMode = GroupPresentationMapper.ResolveSettlementMode(workspace.Overview);
+        foreach (var line in GroupPresentationMapper.BuildWhoOwesWho(workspace.Overview, settlementMode))
             BalanceLines.Add(line);
 
-        OnPropertyChanged(nameof(TripName));
-        OnPropertyChanged(nameof(TripSummaryText));
+        OnPropertyChanged(nameof(GroupName));
+        OnPropertyChanged(nameof(GroupSummaryText));
         OnPropertyChanged(nameof(IsArchived));
         OnPropertyChanged(nameof(CanEdit));
     }
 
     private async void OnDataChanged(object? sender, EventArgs e)
     {
-        // Only refresh if we are showing the currently selected trip.
+        // Only refresh if we are showing the currently selected group.
         if (_overrideGroupId is null)
         {
             await MainThread.InvokeOnMainThreadAsync(LoadAsync);
         }
     }
 
-    private async void OnTripDetailsClicked(object? sender, EventArgs e)
+    private async void OnGroupDetailsClicked(object? sender, EventArgs e)
     {
         if (_overrideGroupId is not null)
         {
-            await Shell.Current.GoToAsync($"{AppRoutes.TripDetails}?groupId={Uri.EscapeDataString(_overrideGroupId)}");
+            await Shell.Current.GoToAsync($"{AppRoutes.GroupDetails}?groupId={Uri.EscapeDataString(_overrideGroupId)}");
         }
         else
         {
-            await Shell.Current.GoToAsync(AppRoutes.TripDetails);
+            await Shell.Current.GoToAsync(AppRoutes.GroupDetails);
         }
     }
 

--- a/src/LuSplit.App/Pages/HomePage.xaml
+++ b/src/LuSplit.App/Pages/HomePage.xaml
@@ -4,23 +4,23 @@
              xmlns:admob="clr-namespace:Plugin.MauiMtAdmob.Controls;assembly=Plugin.MauiMtAdmob"
              xmlns:loc="clr-namespace:LuSplit.App.Resources.Localization"
              x:Class="LuSplit.App.Pages.HomePage"
-             Title="{x:Static loc:AppResources.Trips_Title}">
+             Title="{x:Static loc:AppResources.Groups_Title}">
     <Grid RowDefinitions="*,Auto">
 
-        <!-- Main content: scrollable trip list + New trip button -->
+        <!-- Main content: scrollable group list + New group button -->
         <Grid RowDefinitions="*,Auto,Auto" RowSpacing="0">
             <ScrollView>
                 <VerticalStackLayout Padding="20,24,20,12" Spacing="16">
                     <VerticalStackLayout Spacing="6">
-                        <Label Text="{x:Static loc:AppResources.Trips_Title}" Style="{StaticResource DisplayTitle}" />
-                        <Label Text="{x:Static loc:AppResources.Trips_Subtitle}" Style="{StaticResource BodyMuted}" />
+                        <Label Text="{x:Static loc:AppResources.Groups_Title}" Style="{StaticResource DisplayTitle}" />
+                        <Label Text="{x:Static loc:AppResources.Groups_Subtitle}" Style="{StaticResource BodyMuted}" />
                     </VerticalStackLayout>
 
-                    <CollectionView ItemsSource="{Binding Trips}" SelectionMode="None">
+                    <CollectionView ItemsSource="{Binding Groups}" SelectionMode="None">
                         <CollectionView.EmptyView>
                             <VerticalStackLayout Padding="0,24,0,0" Spacing="8">
-                                <Label Text="{x:Static loc:AppResources.Trips_EmptyTitle}" Style="{StaticResource SectionTitle}" HorizontalTextAlignment="Center" />
-                                <Label Text="{x:Static loc:AppResources.Trips_EmptySubtitle}" Style="{StaticResource BodyMuted}" HorizontalTextAlignment="Center" />
+                                <Label Text="{x:Static loc:AppResources.Groups_EmptyTitle}" Style="{StaticResource SectionTitle}" HorizontalTextAlignment="Center" />
+                                <Label Text="{x:Static loc:AppResources.Groups_EmptySubtitle}" Style="{StaticResource BodyMuted}" HorizontalTextAlignment="Center" />
                             </VerticalStackLayout>
                         </CollectionView.EmptyView>
                         <CollectionView.ItemTemplate>
@@ -36,19 +36,19 @@
                                             <VerticalStackLayout Grid.Column="1" Spacing="4" VerticalOptions="Start">
                                                 <Label Text="{Binding Currency}" Style="{StaticResource BodyMuted}" HorizontalTextAlignment="End" />
                                                 <Border Style="{StaticResource PillBorder}" IsVisible="{Binding IsCurrent}">
-                                                    <Label Text="{x:Static loc:AppResources.Trips_Active}" Style="{StaticResource PillLabel}" TextColor="{StaticResource PanelLeftTeal}" />
+                                                    <Label Text="{x:Static loc:AppResources.Groups_Active}" Style="{StaticResource PillLabel}" TextColor="{StaticResource PanelLeftTeal}" />
                                                 </Border>
                                             </VerticalStackLayout>
                                         </Grid>
                                         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
                                             <Button Grid.Column="0"
-                                                Text="{x:Static loc:AppResources.Trips_Open}"
-                                                Clicked="OnOpenTripClicked"
+                                                Text="{x:Static loc:AppResources.Groups_Open}"
+                                                Clicked="OnOpenGroupClicked"
                                                 CommandParameter="{Binding GroupId}" />
                                             <Button Grid.Column="1"
-                                                Text="{x:Static loc:AppResources.Trips_Details}"
+                                                Text="{x:Static loc:AppResources.Groups_Details}"
                                                 Style="{StaticResource SecondaryButton}"
-                                                Clicked="OnEditTripClicked"
+                                                Clicked="OnEditGroupClicked"
                                                 CommandParameter="{Binding GroupId}"
                                                 WidthRequest="100" />
                                         </Grid>
@@ -62,11 +62,11 @@
 
             <Button Grid.Row="1"
                 Margin="20,12,20,4"
-                Text="{x:Static loc:AppResources.Trips_NewTrip}"
-                Clicked="OnNewTripClicked" />
+                Text="{x:Static loc:AppResources.Groups_NewGroup}"
+                Clicked="OnNewGroupClicked" />
             <Button Grid.Row="2"
                 Margin="20,0,20,20"
-                Text="{x:Static loc:AppResources.Trips_ViewArchived}"
+                Text="{x:Static loc:AppResources.Groups_ViewArchived}"
                 Style="{StaticResource SecondaryButton}"
                 Clicked="OnViewArchivedClicked" />
         </Grid>

--- a/src/LuSplit.App/Pages/HomePage.xaml.cs
+++ b/src/LuSplit.App/Pages/HomePage.xaml.cs
@@ -7,7 +7,7 @@ public partial class HomePage : ContentPage
 {
     private readonly AppDataService _dataService;
 
-    public ObservableCollection<TripListItemModel> Trips { get; } = new();
+    public ObservableCollection<GroupListItemModel> Groups { get; } = new();
 
     public HomePage(AppDataService dataService)
     {
@@ -30,11 +30,11 @@ public partial class HomePage : ContentPage
 
     private async Task LoadAsync()
     {
-        var trips = await _dataService.GetTripsAsync();
+        var groups = await _dataService.GetGroupsAsync();
 
-        Trips.Clear();
-        foreach (var trip in trips)
-            Trips.Add(trip);
+        Groups.Clear();
+        foreach (var group in groups)
+            Groups.Add(group);
     }
 
     private async void OnDataChanged(object? sender, EventArgs e)
@@ -42,31 +42,31 @@ public partial class HomePage : ContentPage
         await MainThread.InvokeOnMainThreadAsync(LoadAsync);
     }
 
-    private async void OnOpenTripClicked(object? sender, EventArgs e)
+    private async void OnOpenGroupClicked(object? sender, EventArgs e)
     {
         if (sender is Button { CommandParameter: string groupId } && !string.IsNullOrWhiteSpace(groupId))
         {
-            await _dataService.SelectTripAsync(groupId);
-            await Shell.Current.GoToAsync(AppRoutes.TripTimeline);
+            await _dataService.SelectGroupAsync(groupId);
+            await Shell.Current.GoToAsync(AppRoutes.GroupTimeline);
         }
     }
 
-    private async void OnEditTripClicked(object? sender, EventArgs e)
+    private async void OnEditGroupClicked(object? sender, EventArgs e)
     {
         if (sender is Button { CommandParameter: string groupId } && !string.IsNullOrWhiteSpace(groupId))
         {
-            await _dataService.SelectTripAsync(groupId);
-            await Shell.Current.GoToAsync(AppRoutes.TripDetails);
+            await _dataService.SelectGroupAsync(groupId);
+            await Shell.Current.GoToAsync(AppRoutes.GroupDetails);
         }
     }
 
-    private async void OnNewTripClicked(object? sender, EventArgs e)
+    private async void OnNewGroupClicked(object? sender, EventArgs e)
     {
-        await Shell.Current.GoToAsync($"{AppRoutes.TripDetails}?mode=create");
+        await Shell.Current.GoToAsync($"{AppRoutes.GroupDetails}?mode=create");
     }
 
     private async void OnViewArchivedClicked(object? sender, EventArgs e)
     {
-        await Shell.Current.GoToAsync(AppRoutes.ArchivedTrips);
+        await Shell.Current.GoToAsync(AppRoutes.ArchivedGroups);
     }
 }

--- a/src/LuSplit.App/Pages/LanguageSettingsPage.xaml.cs
+++ b/src/LuSplit.App/Pages/LanguageSettingsPage.xaml.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using LuSplit.App.Resources.Localization;
 using LuSplit.App.Services;
 
 namespace LuSplit.App.Pages;
@@ -20,9 +21,14 @@ public partial class LanguageSettingsPage : ContentPage
 
         foreach (var option in LocalizationHelper.SupportedLanguages)
         {
+            // The "System Default" entry uses a resource key so its label follows the active language.
+            var displayLabel = string.IsNullOrEmpty(option.Culture)
+                ? $"{option.Flag} {AppResources.Language_SystemDefault}"
+                : option.DisplayLabel;
+
             Languages.Add(new LanguageOptionViewModel(
                 option.Culture,
-                option.DisplayLabel,
+                displayLabel,
                 string.Equals(option.Culture, saved, StringComparison.OrdinalIgnoreCase)));
         }
     }

--- a/src/LuSplit.App/Pages/SettlementPage.xaml.cs
+++ b/src/LuSplit.App/Pages/SettlementPage.xaml.cs
@@ -31,10 +31,10 @@ public partial class SettlementPage : ContentPage
     private async Task LoadAsync()
     {
         var overview = await _dataService.GetOverviewAsync();
-        var settlementMode = TripPresentationMapper.ResolveSettlementMode(overview);
+        var settlementMode = GroupPresentationMapper.ResolveSettlementMode(overview);
 
         WhoOwesWho.Clear();
-        foreach (var line in TripPresentationMapper.BuildWhoOwesWho(overview, settlementMode))
+        foreach (var line in GroupPresentationMapper.BuildWhoOwesWho(overview, settlementMode))
         {
             WhoOwesWho.Add(line);
         }

--- a/src/LuSplit.App/Resources/Localization/AppResources.cs
+++ b/src/LuSplit.App/Resources/Localization/AppResources.cs
@@ -20,66 +20,66 @@ public static class AppResources
     public static string Activity_EmptyTitle => Get(nameof(Activity_EmptyTitle));
     public static string Activity_EmptySubtitle => Get(nameof(Activity_EmptySubtitle));
 
-    // --- Trips (Home) ---
-    public static string Trips_Title => Get(nameof(Trips_Title));
-    public static string Trips_Subtitle => Get(nameof(Trips_Subtitle));
-    public static string Trips_EmptyTitle => Get(nameof(Trips_EmptyTitle));
-    public static string Trips_EmptySubtitle => Get(nameof(Trips_EmptySubtitle));
-    public static string Trips_Open => Get(nameof(Trips_Open));
-    public static string Trips_Details => Get(nameof(Trips_Details));
-    public static string Trips_NewTrip => Get(nameof(Trips_NewTrip));
-    public static string Trips_Active => Get(nameof(Trips_Active));
-    public static string Trips_ViewArchived => Get(nameof(Trips_ViewArchived));
+    // --- Groups (Home) ---
+    public static string Groups_Title => Get(nameof(Groups_Title));
+    public static string Groups_Subtitle => Get(nameof(Groups_Subtitle));
+    public static string Groups_EmptyTitle => Get(nameof(Groups_EmptyTitle));
+    public static string Groups_EmptySubtitle => Get(nameof(Groups_EmptySubtitle));
+    public static string Groups_Open => Get(nameof(Groups_Open));
+    public static string Groups_Details => Get(nameof(Groups_Details));
+    public static string Groups_NewGroup => Get(nameof(Groups_NewGroup));
+    public static string Groups_Active => Get(nameof(Groups_Active));
+    public static string Groups_ViewArchived => Get(nameof(Groups_ViewArchived));
 
-    // --- Trip timeline ---
-    public static string Trip_Title => Get(nameof(Trip_Title));
-    public static string Trip_DetailsButton => Get(nameof(Trip_DetailsButton));
-    public static string Trip_WhoOwesWhat => Get(nameof(Trip_WhoOwesWhat));
-    public static string Trip_EveryoneEven => Get(nameof(Trip_EveryoneEven));
-    public static string Trip_SettleUp => Get(nameof(Trip_SettleUp));
-    public static string Trip_Events => Get(nameof(Trip_Events));
-    public static string Trip_EmptyTitle => Get(nameof(Trip_EmptyTitle));
-    public static string Trip_EmptySubtitle => Get(nameof(Trip_EmptySubtitle));
-    public static string Trip_AddExpense => Get(nameof(Trip_AddExpense));
-    public static string Trip_RecordPayment => Get(nameof(Trip_RecordPayment));
+    // --- Group timeline ---
+    public static string Group_Title => Get(nameof(Group_Title));
+    public static string Group_DetailsButton => Get(nameof(Group_DetailsButton));
+    public static string Group_WhoOwesWhat => Get(nameof(Group_WhoOwesWhat));
+    public static string Group_EveryoneEven => Get(nameof(Group_EveryoneEven));
+    public static string Group_SettleUp => Get(nameof(Group_SettleUp));
+    public static string Group_Events => Get(nameof(Group_Events));
+    public static string Group_EmptyTitle => Get(nameof(Group_EmptyTitle));
+    public static string Group_EmptySubtitle => Get(nameof(Group_EmptySubtitle));
+    public static string Group_AddExpense => Get(nameof(Group_AddExpense));
+    public static string Group_RecordPayment => Get(nameof(Group_RecordPayment));
 
-    // --- Trip Details ---
-    public static string TripDetails_Title => Get(nameof(TripDetails_Title));
-    public static string TripDetails_PageTitleCreate => Get(nameof(TripDetails_PageTitleCreate));
-    public static string TripDetails_PageTitleEdit => Get(nameof(TripDetails_PageTitleEdit));
-    public static string TripDetails_SubtitleCreate => Get(nameof(TripDetails_SubtitleCreate));
-    public static string TripDetails_SubtitleEdit => Get(nameof(TripDetails_SubtitleEdit));
-    public static string TripDetails_TripNameLabel => Get(nameof(TripDetails_TripNameLabel));
-    public static string TripDetails_TripNamePlaceholder => Get(nameof(TripDetails_TripNamePlaceholder));
-    public static string TripDetails_CurrencyLabel => Get(nameof(TripDetails_CurrencyLabel));
-    public static string TripDetails_PeopleSection => Get(nameof(TripDetails_PeopleSection));
-    public static string TripDetails_HouseholdHint => Get(nameof(TripDetails_HouseholdHint));
-    public static string TripDetails_NoPeopleTitle => Get(nameof(TripDetails_NoPeopleTitle));
-    public static string TripDetails_NoPeopleSubtitle => Get(nameof(TripDetails_NoPeopleSubtitle));
-    public static string TripDetails_AddPersonSection => Get(nameof(TripDetails_AddPersonSection));
-    public static string TripDetails_PersonNamePlaceholder => Get(nameof(TripDetails_PersonNamePlaceholder));
-    public static string TripDetails_HouseholdNamePlaceholder => Get(nameof(TripDetails_HouseholdNamePlaceholder));
-    public static string TripDetails_AddPersonButton => Get(nameof(TripDetails_AddPersonButton));
-    public static string TripDetails_CreateButton => Get(nameof(TripDetails_CreateButton));
-    public static string TripDetails_SaveButton => Get(nameof(TripDetails_SaveButton));
-    public static string TripDetails_ExportButton => Get(nameof(TripDetails_ExportButton));
-    public static string TripDetails_SettlesOnOwn => Get(nameof(TripDetails_SettlesOnOwn));
-    public static string TripDetails_PersonAdded => Get(nameof(TripDetails_PersonAdded));
-    public static string TripDetails_PersonAddedNew => Get(nameof(TripDetails_PersonAddedNew));
-    public static string TripDetails_Remove => Get(nameof(TripDetails_Remove));
-    public static string TripDetails_ArchiveButton => Get(nameof(TripDetails_ArchiveButton));
-    public static string TripDetails_ArchiveConfirmTitle => Get(nameof(TripDetails_ArchiveConfirmTitle));
-    public static string TripDetails_ArchiveConfirmMessage => Get(nameof(TripDetails_ArchiveConfirmMessage));
-    public static string TripDetails_ArchiveConfirmYes => Get(nameof(TripDetails_ArchiveConfirmYes));
-    public static string TripDetails_ArchivedStatus => Get(nameof(TripDetails_ArchivedStatus));
-    public static string TripDetails_ConsumptionCategoryLabel => Get(nameof(TripDetails_ConsumptionCategoryLabel));
-    public static string TripDetails_ConsumptionFull => Get(nameof(TripDetails_ConsumptionFull));
-    public static string TripDetails_ConsumptionHalf => Get(nameof(TripDetails_ConsumptionHalf));
-    public static string TripDetails_ConsumptionCustom => Get(nameof(TripDetails_ConsumptionCustom));
-    public static string TripDetails_CustomWeightPlaceholder => Get(nameof(TripDetails_CustomWeightPlaceholder));
-    public static string TripDetails_PersonIsOwner => Get(nameof(TripDetails_PersonIsOwner));
-    public static string TripDetails_PersonIsDependent => Get(nameof(TripDetails_PersonIsDependent));
-    public static string TripDetails_AddPersonHint => Get(nameof(TripDetails_AddPersonHint));
+    // --- Group Details ---
+    public static string GroupDetails_Title => Get(nameof(GroupDetails_Title));
+    public static string GroupDetails_PageTitleCreate => Get(nameof(GroupDetails_PageTitleCreate));
+    public static string GroupDetails_PageTitleEdit => Get(nameof(GroupDetails_PageTitleEdit));
+    public static string GroupDetails_SubtitleCreate => Get(nameof(GroupDetails_SubtitleCreate));
+    public static string GroupDetails_SubtitleEdit => Get(nameof(GroupDetails_SubtitleEdit));
+    public static string GroupDetails_GroupNameLabel => Get(nameof(GroupDetails_GroupNameLabel));
+    public static string GroupDetails_GroupNamePlaceholder => Get(nameof(GroupDetails_GroupNamePlaceholder));
+    public static string GroupDetails_CurrencyLabel => Get(nameof(GroupDetails_CurrencyLabel));
+    public static string GroupDetails_PeopleSection => Get(nameof(GroupDetails_PeopleSection));
+    public static string GroupDetails_HouseholdHint => Get(nameof(GroupDetails_HouseholdHint));
+    public static string GroupDetails_NoPeopleTitle => Get(nameof(GroupDetails_NoPeopleTitle));
+    public static string GroupDetails_NoPeopleSubtitle => Get(nameof(GroupDetails_NoPeopleSubtitle));
+    public static string GroupDetails_AddPersonSection => Get(nameof(GroupDetails_AddPersonSection));
+    public static string GroupDetails_PersonNamePlaceholder => Get(nameof(GroupDetails_PersonNamePlaceholder));
+    public static string GroupDetails_HouseholdNamePlaceholder => Get(nameof(GroupDetails_HouseholdNamePlaceholder));
+    public static string GroupDetails_AddPersonButton => Get(nameof(GroupDetails_AddPersonButton));
+    public static string GroupDetails_CreateButton => Get(nameof(GroupDetails_CreateButton));
+    public static string GroupDetails_SaveButton => Get(nameof(GroupDetails_SaveButton));
+    public static string GroupDetails_ExportButton => Get(nameof(GroupDetails_ExportButton));
+    public static string GroupDetails_SettlesOnOwn => Get(nameof(GroupDetails_SettlesOnOwn));
+    public static string GroupDetails_PersonAdded => Get(nameof(GroupDetails_PersonAdded));
+    public static string GroupDetails_PersonAddedNew => Get(nameof(GroupDetails_PersonAddedNew));
+    public static string GroupDetails_Remove => Get(nameof(GroupDetails_Remove));
+    public static string GroupDetails_ArchiveButton => Get(nameof(GroupDetails_ArchiveButton));
+    public static string GroupDetails_ArchiveConfirmTitle => Get(nameof(GroupDetails_ArchiveConfirmTitle));
+    public static string GroupDetails_ArchiveConfirmMessage => Get(nameof(GroupDetails_ArchiveConfirmMessage));
+    public static string GroupDetails_ArchiveConfirmYes => Get(nameof(GroupDetails_ArchiveConfirmYes));
+    public static string GroupDetails_ArchivedStatus => Get(nameof(GroupDetails_ArchivedStatus));
+    public static string GroupDetails_ConsumptionCategoryLabel => Get(nameof(GroupDetails_ConsumptionCategoryLabel));
+    public static string GroupDetails_ConsumptionFull => Get(nameof(GroupDetails_ConsumptionFull));
+    public static string GroupDetails_ConsumptionHalf => Get(nameof(GroupDetails_ConsumptionHalf));
+    public static string GroupDetails_ConsumptionCustom => Get(nameof(GroupDetails_ConsumptionCustom));
+    public static string GroupDetails_CustomWeightPlaceholder => Get(nameof(GroupDetails_CustomWeightPlaceholder));
+    public static string GroupDetails_PersonIsOwner => Get(nameof(GroupDetails_PersonIsOwner));
+    public static string GroupDetails_PersonIsDependent => Get(nameof(GroupDetails_PersonIsDependent));
+    public static string GroupDetails_AddPersonHint => Get(nameof(GroupDetails_AddPersonHint));
 
     // --- Add Event ---
     public static string AddEvent_Title => Get(nameof(AddEvent_Title));
@@ -132,8 +132,8 @@ public static class AppResources
     public static string Validation_SelectPayer => Get(nameof(Validation_SelectPayer));
     public static string Validation_PickAtLeastOnePerson => Get(nameof(Validation_PickAtLeastOnePerson));
     public static string Validation_PersonNameRequired => Get(nameof(Validation_PersonNameRequired));
-    public static string Validation_TripNotFound => Get(nameof(Validation_TripNotFound));
-    public static string Validation_TripNameRequired => Get(nameof(Validation_TripNameRequired));
+    public static string Validation_GroupNotFound => Get(nameof(Validation_GroupNotFound));
+    public static string Validation_GroupNameRequired => Get(nameof(Validation_GroupNameRequired));
     public static string Validation_SelectCurrency => Get(nameof(Validation_SelectCurrency));
     public static string Validation_AddAtLeastOnePerson => Get(nameof(Validation_AddAtLeastOnePerson));
     public static string Validation_ChooseBothPeople => Get(nameof(Validation_ChooseBothPeople));
@@ -141,7 +141,7 @@ public static class AppResources
     public static string Validation_InvalidCustomWeight => Get(nameof(Validation_InvalidCustomWeight));
     public static string Validation_CustomWeightRequiredForCustomCategory => Get(nameof(Validation_CustomWeightRequiredForCustomCategory));
 
-    // --- Archived trips ---
+    // --- Archived groups ---
     public static string Archived_Title => Get(nameof(Archived_Title));
     public static string Archived_Subtitle => Get(nameof(Archived_Subtitle));
     public static string Archived_EmptyTitle => Get(nameof(Archived_EmptyTitle));
@@ -154,4 +154,41 @@ public static class AppResources
     public static string Settings_LanguageHint => Get(nameof(Settings_LanguageHint));
     public static string Settings_LanguageSaved => Get(nameof(Settings_LanguageSaved));
     public static string Language_SystemDefault => Get(nameof(Language_SystemDefault));
+
+    // --- Validation (service-level) ---
+    public static string Validation_CurrencyRequired => Get(nameof(Validation_CurrencyRequired));
+    public static string Validation_EachPersonNeedsName => Get(nameof(Validation_EachPersonNeedsName));
+
+    // --- Mapper / presentation sentences ---
+    public static string Mapper_Person => Get(nameof(Mapper_Person));
+    public static string Mapper_Everyone => Get(nameof(Mapper_Everyone));
+    public static string Mapper_And => Get(nameof(Mapper_And));
+    public static string Mapper_SplitEqual => Get(nameof(Mapper_SplitEqual));
+    public static string Mapper_SplitWeighted => Get(nameof(Mapper_SplitWeighted));
+    public static string Mapper_SplitByPercentage => Get(nameof(Mapper_SplitByPercentage));
+    public static string Mapper_SplitCustomAmounts => Get(nameof(Mapper_SplitCustomAmounts));
+    public static string Mapper_SplitCustomAmountsOnly => Get(nameof(Mapper_SplitCustomAmountsOnly));
+    public static string Mapper_HouseholdOf => Get(nameof(Mapper_HouseholdOf));
+    public static string Mapper_PaymentTitle => Get(nameof(Mapper_PaymentTitle));
+    public static string Mapper_PaymentPrimaryText => Get(nameof(Mapper_PaymentPrimaryText));
+    public static string Mapper_PaymentSecondaryText => Get(nameof(Mapper_PaymentSecondaryText));
+    public static string Mapper_ActivityExpenseTitle => Get(nameof(Mapper_ActivityExpenseTitle));
+    public static string Mapper_ActivityPaymentTitle => Get(nameof(Mapper_ActivityPaymentTitle));
+    public static string Mapper_ActivityPaymentDetail => Get(nameof(Mapper_ActivityPaymentDetail));
+    public static string Mapper_BalanceOwes => Get(nameof(Mapper_BalanceOwes));
+    public static string Mapper_BalanceEvenNow => Get(nameof(Mapper_BalanceEvenNow));
+    public static string Mapper_SummaryReadyToGo => Get(nameof(Mapper_SummaryReadyToGo));
+    public static string Mapper_SummaryEvents => Get(nameof(Mapper_SummaryEvents));
+    public static string Mapper_Today => Get(nameof(Mapper_Today));
+    public static string Mapper_Yesterday => Get(nameof(Mapper_Yesterday));
+
+    // --- Group status labels ---
+    public static string Status_CurrentGroup => Get(nameof(Status_CurrentGroup));
+    public static string Status_OpenedOn => Get(nameof(Status_OpenedOn));
+    public static string Status_RecentActivity => Get(nameof(Status_RecentActivity));
+    public static string Status_ReadyForFirstEvent => Get(nameof(Status_ReadyForFirstEvent));
+    public static string Status_AddFirstEvent => Get(nameof(Status_AddFirstEvent));
+    public static string Status_Settled => Get(nameof(Status_Settled));
+    public static string Status_DefaultGroupName => Get(nameof(Status_DefaultGroupName));
+    public static string Status_Household => Get(nameof(Status_Household));
 }

--- a/src/LuSplit.App/Resources/Localization/AppResources.de.resx
+++ b/src/LuSplit.App/Resources/Localization/AppResources.de.resx
@@ -17,135 +17,135 @@
     <value>Aktivität</value>
   </data>
   <data name="Activity_Subtitle" xml:space="preserve">
-    <value>Aktuelle Ereignisse Ihrer Reise.</value>
+    <value>Aktuelle Ereignisse Ihrer Gruppe.</value>
   </data>
   <data name="Activity_EmptyTitle" xml:space="preserve">
     <value>Noch nichts hier.</value>
   </data>
   <data name="Activity_EmptySubtitle" xml:space="preserve">
-    <value>Öffnen Sie eine Reise und fügen Sie das erste Ereignis hinzu.</value>
+    <value>Öffnen Sie eine Gruppe und fügen Sie das erste Ereignis hinzu.</value>
   </data>
-  <data name="Trips_Title" xml:space="preserve">
-    <value>Reisen</value>
+  <data name="Groups_Title" xml:space="preserve">
+    <value>Gruppen</value>
   </data>
-  <data name="Trips_Subtitle" xml:space="preserve">
-    <value>Machen Sie dort weiter, wo Sie aufgehört haben, oder starten Sie eine neue Reise.</value>
+  <data name="Groups_Subtitle" xml:space="preserve">
+    <value>Machen Sie dort weiter, wo Sie aufgehört haben, oder starten Sie eine neue Gruppe.</value>
   </data>
-  <data name="Trips_EmptyTitle" xml:space="preserve">
-    <value>Noch keine Reisen.</value>
+  <data name="Groups_EmptyTitle" xml:space="preserve">
+    <value>Noch keine Gruppen.</value>
   </data>
-  <data name="Trips_EmptySubtitle" xml:space="preserve">
-    <value>Erstellen Sie Ihre erste Reise und beginnen Sie Ereignisse hinzuzufügen.</value>
+  <data name="Groups_EmptySubtitle" xml:space="preserve">
+    <value>Erstellen Sie Ihre erste Gruppe und beginnen Sie Ereignisse hinzuzufügen.</value>
   </data>
-  <data name="Trips_Open" xml:space="preserve">
+  <data name="Groups_Open" xml:space="preserve">
     <value>Öffnen</value>
   </data>
-  <data name="Trips_Details" xml:space="preserve">
+  <data name="Groups_Details" xml:space="preserve">
     <value>Details</value>
   </data>
-  <data name="Trips_NewTrip" xml:space="preserve">
-    <value>+ Neue Reise</value>
+  <data name="Groups_NewGroup" xml:space="preserve">
+    <value>+ Neue Gruppe</value>
   </data>
-  <data name="Trips_Active" xml:space="preserve">
+  <data name="Groups_Active" xml:space="preserve">
     <value>Aktiv</value>
   </data>
-  <data name="Trip_Title" xml:space="preserve">
-    <value>Reise</value>
+  <data name="Group_Title" xml:space="preserve">
+    <value>Gruppe</value>
   </data>
-  <data name="Trip_DetailsButton" xml:space="preserve">
+  <data name="Group_DetailsButton" xml:space="preserve">
     <value>Details</value>
   </data>
-  <data name="Trip_WhoOwesWhat" xml:space="preserve">
+  <data name="Group_WhoOwesWhat" xml:space="preserve">
     <value>Wer schuldet was</value>
   </data>
-  <data name="Trip_EveryoneEven" xml:space="preserve">
+  <data name="Group_EveryoneEven" xml:space="preserve">
     <value>Aktuell ist alles ausgeglichen.</value>
   </data>
-  <data name="Trip_SettleUp" xml:space="preserve">
+  <data name="Group_SettleUp" xml:space="preserve">
     <value>Ausgleichen</value>
   </data>
-  <data name="Trip_Events" xml:space="preserve">
+  <data name="Group_Events" xml:space="preserve">
     <value>Ereignisse</value>
   </data>
-  <data name="Trip_EmptyTitle" xml:space="preserve">
-    <value>Ihre Reise hat gerade begonnen.</value>
+  <data name="Group_EmptyTitle" xml:space="preserve">
+    <value>Ihre Gruppe ist bereit.</value>
   </data>
-  <data name="Trip_EmptySubtitle" xml:space="preserve">
+  <data name="Group_EmptySubtitle" xml:space="preserve">
     <value>Fügen Sie unten die erste Ausgabe hinzu.</value>
   </data>
-  <data name="Trip_AddExpense" xml:space="preserve">
+  <data name="Group_AddExpense" xml:space="preserve">
     <value>+ Ausgabe hinzufügen</value>
   </data>
-  <data name="Trip_RecordPayment" xml:space="preserve">
+  <data name="Group_RecordPayment" xml:space="preserve">
     <value>Zahlung erfassen</value>
   </data>
-  <data name="TripDetails_Title" xml:space="preserve">
-    <value>Reisedetails</value>
+  <data name="GroupDetails_Title" xml:space="preserve">
+    <value>Gruppendetails</value>
   </data>
-  <data name="TripDetails_PageTitleCreate" xml:space="preserve">
-    <value>Neue Reise</value>
+  <data name="GroupDetails_PageTitleCreate" xml:space="preserve">
+    <value>Neue Gruppe</value>
   </data>
-  <data name="TripDetails_PageTitleEdit" xml:space="preserve">
-    <value>Reisedetails</value>
+  <data name="GroupDetails_PageTitleEdit" xml:space="preserve">
+    <value>Gruppendetails</value>
   </data>
-  <data name="TripDetails_SubtitleCreate" xml:space="preserve">
-    <value>Richten Sie die Reise einmalig ein und beginnen Sie dann Ereignisse hinzuzufügen.</value>
+  <data name="GroupDetails_SubtitleCreate" xml:space="preserve">
+    <value>Richten Sie die Gruppe einmalig ein und beginnen Sie dann Ereignisse hinzuzufügen.</value>
   </data>
-  <data name="TripDetails_SubtitleEdit" xml:space="preserve">
-    <value>Aktualisieren Sie die Grunddaten und halten Sie die Reise bereit.</value>
+  <data name="GroupDetails_SubtitleEdit" xml:space="preserve">
+    <value>Aktualisieren Sie die Grunddaten und halten Sie die Gruppe bereit.</value>
   </data>
-  <data name="TripDetails_TripNameLabel" xml:space="preserve">
-    <value>Reisename</value>
+  <data name="GroupDetails_GroupNameLabel" xml:space="preserve">
+    <value>Gruppenname</value>
   </data>
-  <data name="TripDetails_TripNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_GroupNamePlaceholder" xml:space="preserve">
     <value>Strandwochenende, Hüttenurlaub...</value>
   </data>
-  <data name="TripDetails_CurrencyLabel" xml:space="preserve">
+  <data name="GroupDetails_CurrencyLabel" xml:space="preserve">
     <value>Währung</value>
   </data>
-  <data name="TripDetails_PeopleSection" xml:space="preserve">
+  <data name="GroupDetails_PeopleSection" xml:space="preserve">
     <value>Personen</value>
   </data>
-  <data name="TripDetails_HouseholdHint" xml:space="preserve">
+  <data name="GroupDetails_HouseholdHint" xml:space="preserve">
     <value>Verwenden Sie denselben Haushaltnamen, wenn Personen gemeinsam abrechnen sollen.</value>
   </data>
-  <data name="TripDetails_NoPeopleTitle" xml:space="preserve">
+  <data name="GroupDetails_NoPeopleTitle" xml:space="preserve">
     <value>Noch keine Personen.</value>
   </data>
-  <data name="TripDetails_NoPeopleSubtitle" xml:space="preserve">
-    <value>Fügen Sie mindestens eine Person hinzu, bevor Sie die Reise speichern.</value>
+  <data name="GroupDetails_NoPeopleSubtitle" xml:space="preserve">
+    <value>Fügen Sie mindestens eine Person hinzu, bevor Sie die Gruppe speichern.</value>
   </data>
-  <data name="TripDetails_AddPersonSection" xml:space="preserve">
+  <data name="GroupDetails_AddPersonSection" xml:space="preserve">
     <value>Person hinzufügen</value>
   </data>
-  <data name="TripDetails_PersonNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_PersonNamePlaceholder" xml:space="preserve">
     <value>Name</value>
   </data>
-  <data name="TripDetails_HouseholdNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_HouseholdNamePlaceholder" xml:space="preserve">
     <value>Haushalt oder Familie (optional)</value>
   </data>
-  <data name="TripDetails_AddPersonButton" xml:space="preserve">
+  <data name="GroupDetails_AddPersonButton" xml:space="preserve">
     <value>Person hinzufügen</value>
   </data>
-  <data name="TripDetails_CreateButton" xml:space="preserve">
-    <value>Reise erstellen</value>
+  <data name="GroupDetails_CreateButton" xml:space="preserve">
+    <value>Gruppe erstellen</value>
   </data>
-  <data name="TripDetails_SaveButton" xml:space="preserve">
-    <value>Reise speichern</value>
+  <data name="GroupDetails_SaveButton" xml:space="preserve">
+    <value>Gruppe speichern</value>
   </data>
-  <data name="TripDetails_ExportButton" xml:space="preserve">
-    <value>Reise exportieren</value>
+  <data name="GroupDetails_ExportButton" xml:space="preserve">
+    <value>Gruppe exportieren</value>
   </data>
-  <data name="TripDetails_SettlesOnOwn" xml:space="preserve">
+  <data name="GroupDetails_SettlesOnOwn" xml:space="preserve">
     <value>Rechnet selbst ab</value>
   </data>
-  <data name="TripDetails_PersonAdded" xml:space="preserve">
+  <data name="GroupDetails_PersonAdded" xml:space="preserve">
     <value>Person hinzugefügt.</value>
   </data>
-  <data name="TripDetails_PersonAddedNew" xml:space="preserve">
-    <value>Person zur neuen Reise hinzugefügt.</value>
+  <data name="GroupDetails_PersonAddedNew" xml:space="preserve">
+    <value>Person zur neuen Gruppe hinzugefügt.</value>
   </data>
-  <data name="TripDetails_Remove" xml:space="preserve">
+  <data name="GroupDetails_Remove" xml:space="preserve">
     <value>Entfernen</value>
   </data>
   <data name="AddEvent_Title" xml:space="preserve">
@@ -215,7 +215,7 @@
     <value>Zahlung erfassen</value>
   </data>
   <data name="RecordPayment_Subtitle" xml:space="preserve">
-    <value>Erfassen Sie eine echte Zahlung und halten Sie die Reise aktuell.</value>
+    <value>Erfassen Sie eine echte Zahlung und halten Sie die Gruppe aktuell.</value>
   </data>
   <data name="RecordPayment_WhoPaid" xml:space="preserve">
     <value>Wer hat gezahlt?</value>
@@ -236,7 +236,7 @@
     <value>Abbrechen</value>
   </data>
   <data name="Export_DialogTitle" xml:space="preserve">
-    <value>Diese Reise exportieren</value>
+    <value>Diese Gruppe exportieren</value>
   </data>
   <data name="Export_JsonOption" xml:space="preserve">
     <value>JSON-Snapshot</value>
@@ -248,7 +248,7 @@
     <value>PDF-Zusammenfassung</value>
   </data>
   <data name="Export_ShareTitle" xml:space="preserve">
-    <value>Reise exportieren</value>
+    <value>Gruppe exportieren</value>
   </data>
   <data name="Export_Failed" xml:space="preserve">
     <value>Export fehlgeschlagen. {0}</value>
@@ -268,11 +268,11 @@
   <data name="Validation_PersonNameRequired" xml:space="preserve">
     <value>Name ist erforderlich.</value>
   </data>
-  <data name="Validation_TripNotFound" xml:space="preserve">
-    <value>Reise nicht gefunden.</value>
+  <data name="Validation_GroupNotFound" xml:space="preserve">
+    <value>Gruppe nicht gefunden.</value>
   </data>
-  <data name="Validation_TripNameRequired" xml:space="preserve">
-    <value>Reisename ist erforderlich.</value>
+  <data name="Validation_GroupNameRequired" xml:space="preserve">
+    <value>Gruppenname ist erforderlich.</value>
   </data>
   <data name="Validation_SelectCurrency" xml:space="preserve">
     <value>Wählen Sie eine Währung.</value>
@@ -300,6 +300,169 @@
   </data>
   <data name="Language_SystemDefault" xml:space="preserve">
     <value>Systemstandard</value>
+  </data>
+
+  <!-- GroupDetails missing keys -->
+  <data name="GroupDetails_ArchiveButton" xml:space="preserve">
+    <value>Gruppe archivieren</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmTitle" xml:space="preserve">
+    <value>Diese Gruppe archivieren?</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmMessage" xml:space="preserve">
+    <value>Diese Gruppe wird archiviert. Sie können sie weiterhin lesen und exportieren, aber keine neuen Ereignisse hinzufügen.</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmYes" xml:space="preserve">
+    <value>Archivieren</value>
+  </data>
+  <data name="GroupDetails_ArchivedStatus" xml:space="preserve">
+    <value>Diese Gruppe ist archiviert und schreibgeschützt.</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCategoryLabel" xml:space="preserve">
+    <value>Verbrauchsanteil</value>
+  </data>
+  <data name="GroupDetails_ConsumptionFull" xml:space="preserve">
+    <value>Voll</value>
+  </data>
+  <data name="GroupDetails_ConsumptionHalf" xml:space="preserve">
+    <value>Halb</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCustom" xml:space="preserve">
+    <value>Benutzerdefiniertes Gewicht</value>
+  </data>
+  <data name="GroupDetails_CustomWeightPlaceholder" xml:space="preserve">
+    <value>z.B. 0,5</value>
+  </data>
+  <data name="GroupDetails_PersonIsOwner" xml:space="preserve">
+    <value>Zahler</value>
+  </data>
+  <data name="GroupDetails_PersonIsDependent" xml:space="preserve">
+    <value>Abhängige Person</value>
+  </data>
+  <data name="GroupDetails_AddPersonHint" xml:space="preserve">
+    <value>Fügen Sie zuerst den Zahler hinzu. Fügen Sie dann Familienmitglieder mit demselben Haushaltnamen hinzu – sie rechnen unter dem Zahler ab.</value>
+  </data>
+  <data name="Validation_InvalidCustomWeight" xml:space="preserve">
+    <value>Geben Sie ein gültiges benutzerdefiniertes Gewicht ein (z.B. 0,5).</value>
+  </data>
+  <data name="Validation_CustomWeightRequiredForCustomCategory" xml:space="preserve">
+    <value>Das benutzerdefinierte Gewicht ist erforderlich, wenn der Verbrauch auf Benutzerdefiniert gesetzt ist.</value>
+  </data>
+
+  <!-- Archived groups -->
+  <data name="Archived_Title" xml:space="preserve">
+    <value>Archivierte Gruppen</value>
+  </data>
+  <data name="Archived_Subtitle" xml:space="preserve">
+    <value>Diese Gruppen sind geschlossen. Sie können sie weiterhin lesen und exportieren.</value>
+  </data>
+  <data name="Archived_EmptyTitle" xml:space="preserve">
+    <value>Noch keine archivierten Gruppen.</value>
+  </data>
+  <data name="Archived_EmptySubtitle" xml:space="preserve">
+    <value>Archivierte Gruppen erscheinen hier.</value>
+  </data>
+  <data name="Archived_Badge" xml:space="preserve">
+    <value>Archiviert</value>
+  </data>
+
+  <!-- Validation (service-level) -->
+  <data name="Validation_CurrencyRequired" xml:space="preserve">
+    <value>Währung ist erforderlich.</value>
+  </data>
+  <data name="Validation_EachPersonNeedsName" xml:space="preserve">
+    <value>Jede Person braucht einen Namen.</value>
+  </data>
+
+  <!-- Mapper / presentation sentences -->
+  <data name="Mapper_Person" xml:space="preserve">
+    <value>Person</value>
+  </data>
+  <data name="Mapper_Everyone" xml:space="preserve">
+    <value>alle</value>
+  </data>
+  <data name="Mapper_And" xml:space="preserve">
+    <value>und</value>
+  </data>
+  <data name="Mapper_SplitEqual" xml:space="preserve">
+    <value>Gleichmäßig aufgeteilt zwischen {0}</value>
+  </data>
+  <data name="Mapper_SplitWeighted" xml:space="preserve">
+    <value>Gewichtet zwischen {0}</value>
+  </data>
+  <data name="Mapper_SplitByPercentage" xml:space="preserve">
+    <value>Nach Prozentsätzen zwischen {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmounts" xml:space="preserve">
+    <value>Mit benutzerdefinierten Beträgen zwischen {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmountsOnly" xml:space="preserve">
+    <value>Benutzerdefinierte Beträge für {0}</value>
+  </data>
+  <data name="Mapper_HouseholdOf" xml:space="preserve">
+    <value>Haushalt von {0}</value>
+  </data>
+  <data name="Mapper_PaymentTitle" xml:space="preserve">
+    <value>Zahlung</value>
+  </data>
+  <data name="Mapper_PaymentPrimaryText" xml:space="preserve">
+    <value>{0} hat {1} bezahlt</value>
+  </data>
+  <data name="Mapper_PaymentSecondaryText" xml:space="preserve">
+    <value>Zahlung erfasst</value>
+  </data>
+  <data name="Mapper_ActivityExpenseTitle" xml:space="preserve">
+    <value>{0} hat {1} hinzugefügt</value>
+  </data>
+  <data name="Mapper_ActivityPaymentTitle" xml:space="preserve">
+    <value>{0} hat {1} bezahlt</value>
+  </data>
+  <data name="Mapper_ActivityPaymentDetail" xml:space="preserve">
+    <value>Zahlung erfasst</value>
+  </data>
+  <data name="Mapper_BalanceOwes" xml:space="preserve">
+    <value>{0} schuldet {1}</value>
+  </data>
+  <data name="Mapper_BalanceEvenNow" xml:space="preserve">
+    <value>Aktuell ist alles ausgeglichen.</value>
+  </data>
+  <data name="Mapper_SummaryReadyToGo" xml:space="preserve">
+    <value>{0} Personen bereit</value>
+  </data>
+  <data name="Mapper_SummaryEvents" xml:space="preserve">
+    <value>{0} Personen · {1} Ereignisse</value>
+  </data>
+  <data name="Mapper_Today" xml:space="preserve">
+    <value>Heute</value>
+  </data>
+  <data name="Mapper_Yesterday" xml:space="preserve">
+    <value>Gestern</value>
+  </data>
+
+  <!-- Group status labels -->
+  <data name="Status_CurrentGroup" xml:space="preserve">
+    <value>Aktuelle Gruppe</value>
+  </data>
+  <data name="Status_OpenedOn" xml:space="preserve">
+    <value>Geöffnet {0}</value>
+  </data>
+  <data name="Status_RecentActivity" xml:space="preserve">
+    <value>Letzte Aktivität {0}</value>
+  </data>
+  <data name="Status_ReadyForFirstEvent" xml:space="preserve">
+    <value>Bereit für das erste Ereignis</value>
+  </data>
+  <data name="Status_AddFirstEvent" xml:space="preserve">
+    <value>Fügen Sie das erste Ereignis hinzu.</value>
+  </data>
+  <data name="Status_Settled" xml:space="preserve">
+    <value>Abgerechnet.</value>
+  </data>
+  <data name="Status_DefaultGroupName" xml:space="preserve">
+    <value>Gruppe</value>
+  </data>
+  <data name="Status_Household" xml:space="preserve">
+    <value>Haushalt</value>
   </data>
 
 </root>

--- a/src/LuSplit.App/Resources/Localization/AppResources.es.resx
+++ b/src/LuSplit.App/Resources/Localization/AppResources.es.resx
@@ -17,135 +17,135 @@
     <value>Actividad</value>
   </data>
   <data name="Activity_Subtitle" xml:space="preserve">
-    <value>Eventos recientes de tu viaje actual.</value>
+    <value>Eventos recientes de tu grupo actual.</value>
   </data>
   <data name="Activity_EmptyTitle" xml:space="preserve">
     <value>Nada aquí todavía.</value>
   </data>
   <data name="Activity_EmptySubtitle" xml:space="preserve">
-    <value>Abre un viaje y añade el primer evento.</value>
+    <value>Abre un grupo y añade el primer evento.</value>
   </data>
-  <data name="Trips_Title" xml:space="preserve">
-    <value>Viajes</value>
+  <data name="Groups_Title" xml:space="preserve">
+    <value>Grupos</value>
   </data>
-  <data name="Trips_Subtitle" xml:space="preserve">
-    <value>Retoma donde lo dejaste o inicia un nuevo viaje.</value>
+  <data name="Groups_Subtitle" xml:space="preserve">
+    <value>Retoma donde lo dejaste o inicia un nuevo grupo.</value>
   </data>
-  <data name="Trips_EmptyTitle" xml:space="preserve">
-    <value>Sin viajes aún.</value>
+  <data name="Groups_EmptyTitle" xml:space="preserve">
+    <value>Sin grupos aún.</value>
   </data>
-  <data name="Trips_EmptySubtitle" xml:space="preserve">
-    <value>Crea tu primer viaje y empieza a añadir eventos.</value>
+  <data name="Groups_EmptySubtitle" xml:space="preserve">
+    <value>Crea tu primer grupo y empieza a añadir eventos.</value>
   </data>
-  <data name="Trips_Open" xml:space="preserve">
+  <data name="Groups_Open" xml:space="preserve">
     <value>Abrir</value>
   </data>
-  <data name="Trips_Details" xml:space="preserve">
+  <data name="Groups_Details" xml:space="preserve">
     <value>Detalles</value>
   </data>
-  <data name="Trips_NewTrip" xml:space="preserve">
-    <value>+ Nuevo viaje</value>
+  <data name="Groups_NewGroup" xml:space="preserve">
+    <value>+ Nuevo grupo</value>
   </data>
-  <data name="Trips_Active" xml:space="preserve">
+  <data name="Groups_Active" xml:space="preserve">
     <value>Activo</value>
   </data>
-  <data name="Trip_Title" xml:space="preserve">
-    <value>Viaje</value>
+  <data name="Group_Title" xml:space="preserve">
+    <value>Grupo</value>
   </data>
-  <data name="Trip_DetailsButton" xml:space="preserve">
+  <data name="Group_DetailsButton" xml:space="preserve">
     <value>Detalles</value>
   </data>
-  <data name="Trip_WhoOwesWhat" xml:space="preserve">
+  <data name="Group_WhoOwesWhat" xml:space="preserve">
     <value>Quién debe qué</value>
   </data>
-  <data name="Trip_EveryoneEven" xml:space="preserve">
+  <data name="Group_EveryoneEven" xml:space="preserve">
     <value>Todos están en paz por ahora.</value>
   </data>
-  <data name="Trip_SettleUp" xml:space="preserve">
+  <data name="Group_SettleUp" xml:space="preserve">
     <value>Saldar</value>
   </data>
-  <data name="Trip_Events" xml:space="preserve">
+  <data name="Group_Events" xml:space="preserve">
     <value>Eventos</value>
   </data>
-  <data name="Trip_EmptyTitle" xml:space="preserve">
-    <value>Tu viaje acaba de comenzar.</value>
+  <data name="Group_EmptyTitle" xml:space="preserve">
+    <value>Tu grupo está listo.</value>
   </data>
-  <data name="Trip_EmptySubtitle" xml:space="preserve">
+  <data name="Group_EmptySubtitle" xml:space="preserve">
     <value>Añade el primer gasto abajo.</value>
   </data>
-  <data name="Trip_AddExpense" xml:space="preserve">
+  <data name="Group_AddExpense" xml:space="preserve">
     <value>+ Añadir gasto</value>
   </data>
-  <data name="Trip_RecordPayment" xml:space="preserve">
+  <data name="Group_RecordPayment" xml:space="preserve">
     <value>Registrar pago</value>
   </data>
-  <data name="TripDetails_Title" xml:space="preserve">
-    <value>Detalles del viaje</value>
+  <data name="GroupDetails_Title" xml:space="preserve">
+    <value>Detalles del grupo</value>
   </data>
-  <data name="TripDetails_PageTitleCreate" xml:space="preserve">
-    <value>Nuevo viaje</value>
+  <data name="GroupDetails_PageTitleCreate" xml:space="preserve">
+    <value>Nuevo grupo</value>
   </data>
-  <data name="TripDetails_PageTitleEdit" xml:space="preserve">
-    <value>Detalles del viaje</value>
+  <data name="GroupDetails_PageTitleEdit" xml:space="preserve">
+    <value>Detalles del grupo</value>
   </data>
-  <data name="TripDetails_SubtitleCreate" xml:space="preserve">
-    <value>Configura el viaje una vez y empieza a añadir eventos.</value>
+  <data name="GroupDetails_SubtitleCreate" xml:space="preserve">
+    <value>Configura el grupo una vez y empieza a añadir eventos.</value>
   </data>
-  <data name="TripDetails_SubtitleEdit" xml:space="preserve">
-    <value>Actualiza lo básico y mantén el viaje listo para el próximo evento.</value>
+  <data name="GroupDetails_SubtitleEdit" xml:space="preserve">
+    <value>Actualiza lo básico y mantén el grupo listo para el próximo evento.</value>
   </data>
-  <data name="TripDetails_TripNameLabel" xml:space="preserve">
-    <value>Nombre del viaje</value>
+  <data name="GroupDetails_GroupNameLabel" xml:space="preserve">
+    <value>Nombre del grupo</value>
   </data>
-  <data name="TripDetails_TripNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_GroupNamePlaceholder" xml:space="preserve">
     <value>Fin de semana en la playa, cabaña...</value>
   </data>
-  <data name="TripDetails_CurrencyLabel" xml:space="preserve">
+  <data name="GroupDetails_CurrencyLabel" xml:space="preserve">
     <value>Moneda</value>
   </data>
-  <data name="TripDetails_PeopleSection" xml:space="preserve">
+  <data name="GroupDetails_PeopleSection" xml:space="preserve">
     <value>Personas</value>
   </data>
-  <data name="TripDetails_HouseholdHint" xml:space="preserve">
+  <data name="GroupDetails_HouseholdHint" xml:space="preserve">
     <value>Usa el mismo nombre de hogar cuando las personas deban saldar juntas.</value>
   </data>
-  <data name="TripDetails_NoPeopleTitle" xml:space="preserve">
+  <data name="GroupDetails_NoPeopleTitle" xml:space="preserve">
     <value>Sin personas aún.</value>
   </data>
-  <data name="TripDetails_NoPeopleSubtitle" xml:space="preserve">
-    <value>Añade al menos una persona antes de guardar el viaje.</value>
+  <data name="GroupDetails_NoPeopleSubtitle" xml:space="preserve">
+    <value>Añade al menos una persona antes de guardar el grupo.</value>
   </data>
-  <data name="TripDetails_AddPersonSection" xml:space="preserve">
+  <data name="GroupDetails_AddPersonSection" xml:space="preserve">
     <value>Añadir persona</value>
   </data>
-  <data name="TripDetails_PersonNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_PersonNamePlaceholder" xml:space="preserve">
     <value>Nombre</value>
   </data>
-  <data name="TripDetails_HouseholdNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_HouseholdNamePlaceholder" xml:space="preserve">
     <value>Hogar o familia (opcional)</value>
   </data>
-  <data name="TripDetails_AddPersonButton" xml:space="preserve">
+  <data name="GroupDetails_AddPersonButton" xml:space="preserve">
     <value>Añadir persona</value>
   </data>
-  <data name="TripDetails_CreateButton" xml:space="preserve">
-    <value>Crear viaje</value>
+  <data name="GroupDetails_CreateButton" xml:space="preserve">
+    <value>Crear grupo</value>
   </data>
-  <data name="TripDetails_SaveButton" xml:space="preserve">
-    <value>Guardar viaje</value>
+  <data name="GroupDetails_SaveButton" xml:space="preserve">
+    <value>Guardar grupo</value>
   </data>
-  <data name="TripDetails_ExportButton" xml:space="preserve">
-    <value>Exportar viaje</value>
+  <data name="GroupDetails_ExportButton" xml:space="preserve">
+    <value>Exportar grupo</value>
   </data>
-  <data name="TripDetails_SettlesOnOwn" xml:space="preserve">
+  <data name="GroupDetails_SettlesOnOwn" xml:space="preserve">
     <value>Paga por cuenta propia</value>
   </data>
-  <data name="TripDetails_PersonAdded" xml:space="preserve">
+  <data name="GroupDetails_PersonAdded" xml:space="preserve">
     <value>Persona añadida.</value>
   </data>
-  <data name="TripDetails_PersonAddedNew" xml:space="preserve">
-    <value>Persona añadida al nuevo viaje.</value>
+  <data name="GroupDetails_PersonAddedNew" xml:space="preserve">
+    <value>Persona añadida al nuevo grupo.</value>
   </data>
-  <data name="TripDetails_Remove" xml:space="preserve">
+  <data name="GroupDetails_Remove" xml:space="preserve">
     <value>Eliminar</value>
   </data>
   <data name="AddEvent_Title" xml:space="preserve">
@@ -215,7 +215,7 @@
     <value>Registrar pago</value>
   </data>
   <data name="RecordPayment_Subtitle" xml:space="preserve">
-    <value>Captura un pago real y mantén la cronología del viaje honesta.</value>
+    <value>Captura un pago real y mantén la cronología del grupo honesta.</value>
   </data>
   <data name="RecordPayment_WhoPaid" xml:space="preserve">
     <value>¿Quién pagó?</value>
@@ -236,7 +236,7 @@
     <value>Cancelar</value>
   </data>
   <data name="Export_DialogTitle" xml:space="preserve">
-    <value>Exportar este viaje</value>
+    <value>Exportar este grupo</value>
   </data>
   <data name="Export_JsonOption" xml:space="preserve">
     <value>Instantánea JSON</value>
@@ -248,7 +248,7 @@
     <value>Resumen PDF</value>
   </data>
   <data name="Export_ShareTitle" xml:space="preserve">
-    <value>Exportar viaje</value>
+    <value>Exportar grupo</value>
   </data>
   <data name="Export_Failed" xml:space="preserve">
     <value>Error al exportar. {0}</value>
@@ -268,11 +268,11 @@
   <data name="Validation_PersonNameRequired" xml:space="preserve">
     <value>El nombre es obligatorio.</value>
   </data>
-  <data name="Validation_TripNotFound" xml:space="preserve">
-    <value>Viaje no encontrado.</value>
+  <data name="Validation_GroupNotFound" xml:space="preserve">
+    <value>Grupo no encontrado.</value>
   </data>
-  <data name="Validation_TripNameRequired" xml:space="preserve">
-    <value>El nombre del viaje es obligatorio.</value>
+  <data name="Validation_GroupNameRequired" xml:space="preserve">
+    <value>El nombre del grupo es obligatorio.</value>
   </data>
   <data name="Validation_SelectCurrency" xml:space="preserve">
     <value>Elige una moneda.</value>
@@ -300,6 +300,169 @@
   </data>
   <data name="Language_SystemDefault" xml:space="preserve">
     <value>Sistema</value>
+  </data>
+
+  <!-- GroupDetails missing keys -->
+  <data name="GroupDetails_ArchiveButton" xml:space="preserve">
+    <value>Archivar grupo</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmTitle" xml:space="preserve">
+    <value>¿Archivar este grupo?</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmMessage" xml:space="preserve">
+    <value>Este grupo se moverá al archivo. Aún puedes leerlo y exportarlo, pero no podrás añadir nuevos eventos.</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmYes" xml:space="preserve">
+    <value>Archivar</value>
+  </data>
+  <data name="GroupDetails_ArchivedStatus" xml:space="preserve">
+    <value>Este grupo está archivado y es de solo lectura.</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCategoryLabel" xml:space="preserve">
+    <value>Participación en el consumo</value>
+  </data>
+  <data name="GroupDetails_ConsumptionFull" xml:space="preserve">
+    <value>Completa</value>
+  </data>
+  <data name="GroupDetails_ConsumptionHalf" xml:space="preserve">
+    <value>Mitad</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCustom" xml:space="preserve">
+    <value>Peso personalizado</value>
+  </data>
+  <data name="GroupDetails_CustomWeightPlaceholder" xml:space="preserve">
+    <value>ej. 0,5</value>
+  </data>
+  <data name="GroupDetails_PersonIsOwner" xml:space="preserve">
+    <value>Pagador</value>
+  </data>
+  <data name="GroupDetails_PersonIsDependent" xml:space="preserve">
+    <value>Dependiente</value>
+  </data>
+  <data name="GroupDetails_AddPersonHint" xml:space="preserve">
+    <value>Añade primero al pagador. Luego añade familiares con el mismo nombre de hogar para que liquiden bajo el pagador.</value>
+  </data>
+  <data name="Validation_InvalidCustomWeight" xml:space="preserve">
+    <value>Introduce un peso personalizado válido (ej. 0,5).</value>
+  </data>
+  <data name="Validation_CustomWeightRequiredForCustomCategory" xml:space="preserve">
+    <value>El peso personalizado es obligatorio cuando el consumo es Personalizado.</value>
+  </data>
+
+  <!-- Archived groups -->
+  <data name="Archived_Title" xml:space="preserve">
+    <value>Grupos archivados</value>
+  </data>
+  <data name="Archived_Subtitle" xml:space="preserve">
+    <value>Estos grupos están cerrados. Aún puedes leerlos y exportarlos.</value>
+  </data>
+  <data name="Archived_EmptyTitle" xml:space="preserve">
+    <value>Aún no hay grupos archivados.</value>
+  </data>
+  <data name="Archived_EmptySubtitle" xml:space="preserve">
+    <value>Los grupos archivados aparecen aquí.</value>
+  </data>
+  <data name="Archived_Badge" xml:space="preserve">
+    <value>Archivado</value>
+  </data>
+
+  <!-- Validation (service-level) -->
+  <data name="Validation_CurrencyRequired" xml:space="preserve">
+    <value>La moneda es obligatoria.</value>
+  </data>
+  <data name="Validation_EachPersonNeedsName" xml:space="preserve">
+    <value>Cada persona necesita un nombre.</value>
+  </data>
+
+  <!-- Mapper / presentation sentences -->
+  <data name="Mapper_Person" xml:space="preserve">
+    <value>Persona</value>
+  </data>
+  <data name="Mapper_Everyone" xml:space="preserve">
+    <value>todos</value>
+  </data>
+  <data name="Mapper_And" xml:space="preserve">
+    <value>y</value>
+  </data>
+  <data name="Mapper_SplitEqual" xml:space="preserve">
+    <value>Dividido equitativamente entre {0}</value>
+  </data>
+  <data name="Mapper_SplitWeighted" xml:space="preserve">
+    <value>Ponderado entre {0}</value>
+  </data>
+  <data name="Mapper_SplitByPercentage" xml:space="preserve">
+    <value>Compartido por porcentajes entre {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmounts" xml:space="preserve">
+    <value>Compartido con importes personalizados entre {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmountsOnly" xml:space="preserve">
+    <value>Importes personalizados para {0}</value>
+  </data>
+  <data name="Mapper_HouseholdOf" xml:space="preserve">
+    <value>Hogar de {0}</value>
+  </data>
+  <data name="Mapper_PaymentTitle" xml:space="preserve">
+    <value>Pago</value>
+  </data>
+  <data name="Mapper_PaymentPrimaryText" xml:space="preserve">
+    <value>{0} pagó a {1}</value>
+  </data>
+  <data name="Mapper_PaymentSecondaryText" xml:space="preserve">
+    <value>Pago registrado</value>
+  </data>
+  <data name="Mapper_ActivityExpenseTitle" xml:space="preserve">
+    <value>{0} añadió {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentTitle" xml:space="preserve">
+    <value>{0} pagó a {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentDetail" xml:space="preserve">
+    <value>Pago registrado</value>
+  </data>
+  <data name="Mapper_BalanceOwes" xml:space="preserve">
+    <value>{0} le debe a {1}</value>
+  </data>
+  <data name="Mapper_BalanceEvenNow" xml:space="preserve">
+    <value>Ahora mismo todos están en paz.</value>
+  </data>
+  <data name="Mapper_SummaryReadyToGo" xml:space="preserve">
+    <value>{0} personas listas</value>
+  </data>
+  <data name="Mapper_SummaryEvents" xml:space="preserve">
+    <value>{0} personas · {1} eventos</value>
+  </data>
+  <data name="Mapper_Today" xml:space="preserve">
+    <value>Hoy</value>
+  </data>
+  <data name="Mapper_Yesterday" xml:space="preserve">
+    <value>Ayer</value>
+  </data>
+
+  <!-- Group status labels -->
+  <data name="Status_CurrentGroup" xml:space="preserve">
+    <value>Grupo actual</value>
+  </data>
+  <data name="Status_OpenedOn" xml:space="preserve">
+    <value>Abierto {0}</value>
+  </data>
+  <data name="Status_RecentActivity" xml:space="preserve">
+    <value>Actividad reciente {0}</value>
+  </data>
+  <data name="Status_ReadyForFirstEvent" xml:space="preserve">
+    <value>Listo para el primer evento</value>
+  </data>
+  <data name="Status_AddFirstEvent" xml:space="preserve">
+    <value>Añade el primer evento.</value>
+  </data>
+  <data name="Status_Settled" xml:space="preserve">
+    <value>Saldado.</value>
+  </data>
+  <data name="Status_DefaultGroupName" xml:space="preserve">
+    <value>Grupo</value>
+  </data>
+  <data name="Status_Household" xml:space="preserve">
+    <value>Hogar</value>
   </data>
 
 </root>

--- a/src/LuSplit.App/Resources/Localization/AppResources.fr.resx
+++ b/src/LuSplit.App/Resources/Localization/AppResources.fr.resx
@@ -17,135 +17,135 @@
     <value>Activité</value>
   </data>
   <data name="Activity_Subtitle" xml:space="preserve">
-    <value>Événements récents de votre voyage actuel.</value>
+    <value>Événements récents de votre groupe actuel.</value>
   </data>
   <data name="Activity_EmptyTitle" xml:space="preserve">
     <value>Rien ici pour l'instant.</value>
   </data>
   <data name="Activity_EmptySubtitle" xml:space="preserve">
-    <value>Ouvrez un voyage et ajoutez le premier événement.</value>
+    <value>Ouvrez un groupe et ajoutez le premier événement.</value>
   </data>
-  <data name="Trips_Title" xml:space="preserve">
-    <value>Voyages</value>
+  <data name="Groups_Title" xml:space="preserve">
+    <value>Groupes</value>
   </data>
-  <data name="Trips_Subtitle" xml:space="preserve">
-    <value>Reprenez là où vous en étiez ou démarrez un nouveau voyage.</value>
+  <data name="Groups_Subtitle" xml:space="preserve">
+    <value>Reprenez là où vous en étiez ou démarrez un nouveau groupe.</value>
   </data>
-  <data name="Trips_EmptyTitle" xml:space="preserve">
-    <value>Aucun voyage pour l'instant.</value>
+  <data name="Groups_EmptyTitle" xml:space="preserve">
+    <value>Aucun groupe pour l'instant.</value>
   </data>
-  <data name="Trips_EmptySubtitle" xml:space="preserve">
-    <value>Créez votre premier voyage et commencez à ajouter des événements.</value>
+  <data name="Groups_EmptySubtitle" xml:space="preserve">
+    <value>Créez votre premier groupe et commencez à ajouter des événements.</value>
   </data>
-  <data name="Trips_Open" xml:space="preserve">
+  <data name="Groups_Open" xml:space="preserve">
     <value>Ouvrir</value>
   </data>
-  <data name="Trips_Details" xml:space="preserve">
+  <data name="Groups_Details" xml:space="preserve">
     <value>Détails</value>
   </data>
-  <data name="Trips_NewTrip" xml:space="preserve">
-    <value>+ Nouveau voyage</value>
+  <data name="Groups_NewGroup" xml:space="preserve">
+    <value>+ Nouveau groupe</value>
   </data>
-  <data name="Trips_Active" xml:space="preserve">
+  <data name="Groups_Active" xml:space="preserve">
     <value>Actif</value>
   </data>
-  <data name="Trip_Title" xml:space="preserve">
-    <value>Voyage</value>
+  <data name="Group_Title" xml:space="preserve">
+    <value>Groupe</value>
   </data>
-  <data name="Trip_DetailsButton" xml:space="preserve">
+  <data name="Group_DetailsButton" xml:space="preserve">
     <value>Détails</value>
   </data>
-  <data name="Trip_WhoOwesWhat" xml:space="preserve">
+  <data name="Group_WhoOwesWhat" xml:space="preserve">
     <value>Qui doit quoi</value>
   </data>
-  <data name="Trip_EveryoneEven" xml:space="preserve">
+  <data name="Group_EveryoneEven" xml:space="preserve">
     <value>Tout le monde est quitte pour l'instant.</value>
   </data>
-  <data name="Trip_SettleUp" xml:space="preserve">
+  <data name="Group_SettleUp" xml:space="preserve">
     <value>Solder</value>
   </data>
-  <data name="Trip_Events" xml:space="preserve">
+  <data name="Group_Events" xml:space="preserve">
     <value>Événements</value>
   </data>
-  <data name="Trip_EmptyTitle" xml:space="preserve">
-    <value>Votre voyage vient de commencer.</value>
+  <data name="Group_EmptyTitle" xml:space="preserve">
+    <value>Votre groupe est prêt.</value>
   </data>
-  <data name="Trip_EmptySubtitle" xml:space="preserve">
+  <data name="Group_EmptySubtitle" xml:space="preserve">
     <value>Ajoutez la première dépense ci-dessous.</value>
   </data>
-  <data name="Trip_AddExpense" xml:space="preserve">
+  <data name="Group_AddExpense" xml:space="preserve">
     <value>+ Ajouter une dépense</value>
   </data>
-  <data name="Trip_RecordPayment" xml:space="preserve">
+  <data name="Group_RecordPayment" xml:space="preserve">
     <value>Enregistrer un paiement</value>
   </data>
-  <data name="TripDetails_Title" xml:space="preserve">
-    <value>Détails du voyage</value>
+  <data name="GroupDetails_Title" xml:space="preserve">
+    <value>Détails du groupe</value>
   </data>
-  <data name="TripDetails_PageTitleCreate" xml:space="preserve">
-    <value>Nouveau voyage</value>
+  <data name="GroupDetails_PageTitleCreate" xml:space="preserve">
+    <value>Nouveau groupe</value>
   </data>
-  <data name="TripDetails_PageTitleEdit" xml:space="preserve">
-    <value>Détails du voyage</value>
+  <data name="GroupDetails_PageTitleEdit" xml:space="preserve">
+    <value>Détails du groupe</value>
   </data>
-  <data name="TripDetails_SubtitleCreate" xml:space="preserve">
-    <value>Configurez le voyage une fois, puis commencez à ajouter des événements.</value>
+  <data name="GroupDetails_SubtitleCreate" xml:space="preserve">
+    <value>Configurer le groupe une fois, puis commencer à ajouter des événements.</value>
   </data>
-  <data name="TripDetails_SubtitleEdit" xml:space="preserve">
-    <value>Mettez à jour les bases et gardez le voyage prêt pour le prochain événement.</value>
+  <data name="GroupDetails_SubtitleEdit" xml:space="preserve">
+    <value>Mettez à jour les bases et gardez le groupe prêt pour le prochain événement.</value>
   </data>
-  <data name="TripDetails_TripNameLabel" xml:space="preserve">
-    <value>Nom du voyage</value>
+  <data name="GroupDetails_GroupNameLabel" xml:space="preserve">
+    <value>Nom du groupe</value>
   </data>
-  <data name="TripDetails_TripNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_GroupNamePlaceholder" xml:space="preserve">
     <value>Week-end à la plage, séjour en chalet...</value>
   </data>
-  <data name="TripDetails_CurrencyLabel" xml:space="preserve">
+  <data name="GroupDetails_CurrencyLabel" xml:space="preserve">
     <value>Devise</value>
   </data>
-  <data name="TripDetails_PeopleSection" xml:space="preserve">
+  <data name="GroupDetails_PeopleSection" xml:space="preserve">
     <value>Participants</value>
   </data>
-  <data name="TripDetails_HouseholdHint" xml:space="preserve">
+  <data name="GroupDetails_HouseholdHint" xml:space="preserve">
     <value>Utilisez le même nom de foyer quand des personnes doivent régler ensemble.</value>
   </data>
-  <data name="TripDetails_NoPeopleTitle" xml:space="preserve">
+  <data name="GroupDetails_NoPeopleTitle" xml:space="preserve">
     <value>Aucun participant pour l'instant.</value>
   </data>
-  <data name="TripDetails_NoPeopleSubtitle" xml:space="preserve">
-    <value>Ajoutez au moins une personne avant de sauvegarder le voyage.</value>
+  <data name="GroupDetails_NoPeopleSubtitle" xml:space="preserve">
+    <value>Ajoutez au moins une personne avant de sauvegarder le groupe.</value>
   </data>
-  <data name="TripDetails_AddPersonSection" xml:space="preserve">
+  <data name="GroupDetails_AddPersonSection" xml:space="preserve">
     <value>Ajouter une personne</value>
   </data>
-  <data name="TripDetails_PersonNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_PersonNamePlaceholder" xml:space="preserve">
     <value>Prénom</value>
   </data>
-  <data name="TripDetails_HouseholdNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_HouseholdNamePlaceholder" xml:space="preserve">
     <value>Foyer ou famille (facultatif)</value>
   </data>
-  <data name="TripDetails_AddPersonButton" xml:space="preserve">
+  <data name="GroupDetails_AddPersonButton" xml:space="preserve">
     <value>Ajouter une personne</value>
   </data>
-  <data name="TripDetails_CreateButton" xml:space="preserve">
-    <value>Créer le voyage</value>
+  <data name="GroupDetails_CreateButton" xml:space="preserve">
+    <value>Créer le groupe</value>
   </data>
-  <data name="TripDetails_SaveButton" xml:space="preserve">
+  <data name="GroupDetails_SaveButton" xml:space="preserve">
     <value>Sauvegarder</value>
   </data>
-  <data name="TripDetails_ExportButton" xml:space="preserve">
-    <value>Exporter le voyage</value>
+  <data name="GroupDetails_ExportButton" xml:space="preserve">
+    <value>Exporter le groupe</value>
   </data>
-  <data name="TripDetails_SettlesOnOwn" xml:space="preserve">
+  <data name="GroupDetails_SettlesOnOwn" xml:space="preserve">
     <value>Règle seul</value>
   </data>
-  <data name="TripDetails_PersonAdded" xml:space="preserve">
+  <data name="GroupDetails_PersonAdded" xml:space="preserve">
     <value>Personne ajoutée.</value>
   </data>
-  <data name="TripDetails_PersonAddedNew" xml:space="preserve">
-    <value>Personne ajoutée au nouveau voyage.</value>
+  <data name="GroupDetails_PersonAddedNew" xml:space="preserve">
+    <value>Personne ajoutée au nouveau groupe.</value>
   </data>
-  <data name="TripDetails_Remove" xml:space="preserve">
+  <data name="GroupDetails_Remove" xml:space="preserve">
     <value>Supprimer</value>
   </data>
   <data name="AddEvent_Title" xml:space="preserve">
@@ -215,7 +215,7 @@
     <value>Enregistrer un paiement</value>
   </data>
   <data name="RecordPayment_Subtitle" xml:space="preserve">
-    <value>Capturez un vrai paiement et gardez la chronologie du voyage honnête.</value>
+    <value>Capturez un vrai paiement et gardez la chronologie du groupe honnête.</value>
   </data>
   <data name="RecordPayment_WhoPaid" xml:space="preserve">
     <value>Qui a payé ?</value>
@@ -236,7 +236,7 @@
     <value>Annuler</value>
   </data>
   <data name="Export_DialogTitle" xml:space="preserve">
-    <value>Exporter ce voyage</value>
+    <value>Exporter ce groupe</value>
   </data>
   <data name="Export_JsonOption" xml:space="preserve">
     <value>Instantané JSON</value>
@@ -248,7 +248,7 @@
     <value>Résumé PDF</value>
   </data>
   <data name="Export_ShareTitle" xml:space="preserve">
-    <value>Exporter le voyage</value>
+    <value>Exporter le groupe</value>
   </data>
   <data name="Export_Failed" xml:space="preserve">
     <value>Échec de l'export. {0}</value>
@@ -268,11 +268,11 @@
   <data name="Validation_PersonNameRequired" xml:space="preserve">
     <value>Le nom est obligatoire.</value>
   </data>
-  <data name="Validation_TripNotFound" xml:space="preserve">
-    <value>Voyage introuvable.</value>
+  <data name="Validation_GroupNotFound" xml:space="preserve">
+    <value>Groupe introuvable.</value>
   </data>
-  <data name="Validation_TripNameRequired" xml:space="preserve">
-    <value>Le nom du voyage est obligatoire.</value>
+  <data name="Validation_GroupNameRequired" xml:space="preserve">
+    <value>Le nom du groupe est obligatoire.</value>
   </data>
   <data name="Validation_SelectCurrency" xml:space="preserve">
     <value>Choisissez une devise.</value>
@@ -300,6 +300,169 @@
   </data>
   <data name="Language_SystemDefault" xml:space="preserve">
     <value>Système</value>
+  </data>
+
+  <!-- GroupDetails missing keys -->
+  <data name="GroupDetails_ArchiveButton" xml:space="preserve">
+    <value>Archiver le groupe</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmTitle" xml:space="preserve">
+    <value>Archiver ce groupe ?</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmMessage" xml:space="preserve">
+    <value>Ce groupe sera archivé. Vous pourrez toujours le lire et l'exporter, mais vous ne pourrez plus ajouter de nouveaux événements.</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmYes" xml:space="preserve">
+    <value>Archiver</value>
+  </data>
+  <data name="GroupDetails_ArchivedStatus" xml:space="preserve">
+    <value>Ce groupe est archivé et en lecture seule.</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCategoryLabel" xml:space="preserve">
+    <value>Part de consommation</value>
+  </data>
+  <data name="GroupDetails_ConsumptionFull" xml:space="preserve">
+    <value>Complète</value>
+  </data>
+  <data name="GroupDetails_ConsumptionHalf" xml:space="preserve">
+    <value>Moitié</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCustom" xml:space="preserve">
+    <value>Pondération personnalisée</value>
+  </data>
+  <data name="GroupDetails_CustomWeightPlaceholder" xml:space="preserve">
+    <value>ex. 0,5</value>
+  </data>
+  <data name="GroupDetails_PersonIsOwner" xml:space="preserve">
+    <value>Payeur</value>
+  </data>
+  <data name="GroupDetails_PersonIsDependent" xml:space="preserve">
+    <value>Dépendant</value>
+  </data>
+  <data name="GroupDetails_AddPersonHint" xml:space="preserve">
+    <value>Ajoutez d'abord le payeur. Ajoutez ensuite les membres de la famille avec le même nom de foyer — ils régleront sous le payeur.</value>
+  </data>
+  <data name="Validation_InvalidCustomWeight" xml:space="preserve">
+    <value>Entrez une pondération personnalisée valide (ex. 0,5).</value>
+  </data>
+  <data name="Validation_CustomWeightRequiredForCustomCategory" xml:space="preserve">
+    <value>La pondération personnalisée est requise quand la consommation est définie sur Personnalisé.</value>
+  </data>
+
+  <!-- Archived groups -->
+  <data name="Archived_Title" xml:space="preserve">
+    <value>Groupes archivés</value>
+  </data>
+  <data name="Archived_Subtitle" xml:space="preserve">
+    <value>Ces groupes sont fermés. Vous pouvez toujours les lire et les exporter.</value>
+  </data>
+  <data name="Archived_EmptyTitle" xml:space="preserve">
+    <value>Aucun groupe archivé pour l'instant.</value>
+  </data>
+  <data name="Archived_EmptySubtitle" xml:space="preserve">
+    <value>Les groupes archivés apparaissent ici.</value>
+  </data>
+  <data name="Archived_Badge" xml:space="preserve">
+    <value>Archivé</value>
+  </data>
+
+  <!-- Validation (service-level) -->
+  <data name="Validation_CurrencyRequired" xml:space="preserve">
+    <value>La devise est requise.</value>
+  </data>
+  <data name="Validation_EachPersonNeedsName" xml:space="preserve">
+    <value>Chaque personne a besoin d'un nom.</value>
+  </data>
+
+  <!-- Mapper / presentation sentences -->
+  <data name="Mapper_Person" xml:space="preserve">
+    <value>Personne</value>
+  </data>
+  <data name="Mapper_Everyone" xml:space="preserve">
+    <value>tout le monde</value>
+  </data>
+  <data name="Mapper_And" xml:space="preserve">
+    <value>et</value>
+  </data>
+  <data name="Mapper_SplitEqual" xml:space="preserve">
+    <value>Partagé équitablement entre {0}</value>
+  </data>
+  <data name="Mapper_SplitWeighted" xml:space="preserve">
+    <value>Pondéré entre {0}</value>
+  </data>
+  <data name="Mapper_SplitByPercentage" xml:space="preserve">
+    <value>Partagé par pourcentages entre {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmounts" xml:space="preserve">
+    <value>Partagé avec des montants personnalisés entre {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmountsOnly" xml:space="preserve">
+    <value>Montants personnalisés pour {0}</value>
+  </data>
+  <data name="Mapper_HouseholdOf" xml:space="preserve">
+    <value>Foyer de {0}</value>
+  </data>
+  <data name="Mapper_PaymentTitle" xml:space="preserve">
+    <value>Paiement</value>
+  </data>
+  <data name="Mapper_PaymentPrimaryText" xml:space="preserve">
+    <value>{0} a payé {1}</value>
+  </data>
+  <data name="Mapper_PaymentSecondaryText" xml:space="preserve">
+    <value>Paiement enregistré</value>
+  </data>
+  <data name="Mapper_ActivityExpenseTitle" xml:space="preserve">
+    <value>{0} a ajouté {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentTitle" xml:space="preserve">
+    <value>{0} a payé {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentDetail" xml:space="preserve">
+    <value>Paiement enregistré</value>
+  </data>
+  <data name="Mapper_BalanceOwes" xml:space="preserve">
+    <value>{0} doit {1}</value>
+  </data>
+  <data name="Mapper_BalanceEvenNow" xml:space="preserve">
+    <value>Tout le monde est quitte pour l'instant.</value>
+  </data>
+  <data name="Mapper_SummaryReadyToGo" xml:space="preserve">
+    <value>{0} personnes prêtes</value>
+  </data>
+  <data name="Mapper_SummaryEvents" xml:space="preserve">
+    <value>{0} personnes · {1} événements</value>
+  </data>
+  <data name="Mapper_Today" xml:space="preserve">
+    <value>Aujourd'hui</value>
+  </data>
+  <data name="Mapper_Yesterday" xml:space="preserve">
+    <value>Hier</value>
+  </data>
+
+  <!-- Group status labels -->
+  <data name="Status_CurrentGroup" xml:space="preserve">
+    <value>Groupe actuel</value>
+  </data>
+  <data name="Status_OpenedOn" xml:space="preserve">
+    <value>Ouvert {0}</value>
+  </data>
+  <data name="Status_RecentActivity" xml:space="preserve">
+    <value>Activité récente {0}</value>
+  </data>
+  <data name="Status_ReadyForFirstEvent" xml:space="preserve">
+    <value>Prêt pour le premier événement</value>
+  </data>
+  <data name="Status_AddFirstEvent" xml:space="preserve">
+    <value>Ajoutez le premier événement.</value>
+  </data>
+  <data name="Status_Settled" xml:space="preserve">
+    <value>Soldé.</value>
+  </data>
+  <data name="Status_DefaultGroupName" xml:space="preserve">
+    <value>Groupe</value>
+  </data>
+  <data name="Status_Household" xml:space="preserve">
+    <value>Foyer</value>
   </data>
 
 </root>

--- a/src/LuSplit.App/Resources/Localization/AppResources.it.resx
+++ b/src/LuSplit.App/Resources/Localization/AppResources.it.resx
@@ -17,135 +17,135 @@
     <value>Attività</value>
   </data>
   <data name="Activity_Subtitle" xml:space="preserve">
-    <value>Eventi recenti del tuo viaggio attuale.</value>
+    <value>Eventi recenti del tuo gruppo attuale.</value>
   </data>
   <data name="Activity_EmptyTitle" xml:space="preserve">
     <value>Ancora nulla qui.</value>
   </data>
   <data name="Activity_EmptySubtitle" xml:space="preserve">
-    <value>Apri un viaggio e aggiungi il primo evento.</value>
+    <value>Apri un gruppo e aggiungi il primo evento.</value>
   </data>
-  <data name="Trips_Title" xml:space="preserve">
-    <value>Viaggi</value>
+  <data name="Groups_Title" xml:space="preserve">
+    <value>Gruppi</value>
   </data>
-  <data name="Trips_Subtitle" xml:space="preserve">
-    <value>Riprendi da dove avevi lasciato o inizia un nuovo viaggio.</value>
+  <data name="Groups_Subtitle" xml:space="preserve">
+    <value>Riprendi da dove avevi lasciato o inizia un nuovo gruppo.</value>
   </data>
-  <data name="Trips_EmptyTitle" xml:space="preserve">
-    <value>Ancora nessun viaggio.</value>
+  <data name="Groups_EmptyTitle" xml:space="preserve">
+    <value>Ancora nessun gruppo.</value>
   </data>
-  <data name="Trips_EmptySubtitle" xml:space="preserve">
-    <value>Crea il tuo primo viaggio e inizia ad aggiungere eventi.</value>
+  <data name="Groups_EmptySubtitle" xml:space="preserve">
+    <value>Crea il tuo primo gruppo e inizia ad aggiungere eventi.</value>
   </data>
-  <data name="Trips_Open" xml:space="preserve">
+  <data name="Groups_Open" xml:space="preserve">
     <value>Apri</value>
   </data>
-  <data name="Trips_Details" xml:space="preserve">
+  <data name="Groups_Details" xml:space="preserve">
     <value>Dettagli</value>
   </data>
-  <data name="Trips_NewTrip" xml:space="preserve">
-    <value>+ Nuovo viaggio</value>
+  <data name="Groups_NewGroup" xml:space="preserve">
+    <value>+ Nuovo gruppo</value>
   </data>
-  <data name="Trips_Active" xml:space="preserve">
+  <data name="Groups_Active" xml:space="preserve">
     <value>Attivo</value>
   </data>
-  <data name="Trip_Title" xml:space="preserve">
+  <data name="Group_Title" xml:space="preserve">
     <value>Viaggio</value>
   </data>
-  <data name="Trip_DetailsButton" xml:space="preserve">
+  <data name="Group_DetailsButton" xml:space="preserve">
     <value>Dettagli</value>
   </data>
-  <data name="Trip_WhoOwesWhat" xml:space="preserve">
+  <data name="Group_WhoOwesWhat" xml:space="preserve">
     <value>Chi deve cosa</value>
   </data>
-  <data name="Trip_EveryoneEven" xml:space="preserve">
+  <data name="Group_EveryoneEven" xml:space="preserve">
     <value>Al momento sono tutti pari.</value>
   </data>
-  <data name="Trip_SettleUp" xml:space="preserve">
+  <data name="Group_SettleUp" xml:space="preserve">
     <value>Saldare</value>
   </data>
-  <data name="Trip_Events" xml:space="preserve">
+  <data name="Group_Events" xml:space="preserve">
     <value>Eventi</value>
   </data>
-  <data name="Trip_EmptyTitle" xml:space="preserve">
-    <value>Il tuo viaggio è appena iniziato.</value>
+  <data name="Group_EmptyTitle" xml:space="preserve">
+    <value>Il tuo gruppo è pronto.</value>
   </data>
-  <data name="Trip_EmptySubtitle" xml:space="preserve">
+  <data name="Group_EmptySubtitle" xml:space="preserve">
     <value>Aggiungi la prima spesa qui sotto.</value>
   </data>
-  <data name="Trip_AddExpense" xml:space="preserve">
+  <data name="Group_AddExpense" xml:space="preserve">
     <value>+ Aggiungi spesa</value>
   </data>
-  <data name="Trip_RecordPayment" xml:space="preserve">
+  <data name="Group_RecordPayment" xml:space="preserve">
     <value>Registra pagamento</value>
   </data>
-  <data name="TripDetails_Title" xml:space="preserve">
-    <value>Dettagli viaggio</value>
+  <data name="GroupDetails_Title" xml:space="preserve">
+    <value>Dettagli gruppo</value>
   </data>
-  <data name="TripDetails_PageTitleCreate" xml:space="preserve">
-    <value>Nuovo viaggio</value>
+  <data name="GroupDetails_PageTitleCreate" xml:space="preserve">
+    <value>Nuovo gruppo</value>
   </data>
-  <data name="TripDetails_PageTitleEdit" xml:space="preserve">
-    <value>Dettagli viaggio</value>
+  <data name="GroupDetails_PageTitleEdit" xml:space="preserve">
+    <value>Dettagli gruppo</value>
   </data>
-  <data name="TripDetails_SubtitleCreate" xml:space="preserve">
-    <value>Configura il viaggio una volta, poi inizia ad aggiungere eventi.</value>
+  <data name="GroupDetails_SubtitleCreate" xml:space="preserve">
+    <value>Configura il gruppo una volta, poi inizia ad aggiungere eventi.</value>
   </data>
-  <data name="TripDetails_SubtitleEdit" xml:space="preserve">
-    <value>Aggiorna le informazioni di base e tieni il viaggio pronto.</value>
+  <data name="GroupDetails_SubtitleEdit" xml:space="preserve">
+    <value>Aggiorna le informazioni di base e tieni il gruppo pronto.</value>
   </data>
-  <data name="TripDetails_TripNameLabel" xml:space="preserve">
-    <value>Nome del viaggio</value>
+  <data name="GroupDetails_GroupNameLabel" xml:space="preserve">
+    <value>Nome del gruppo</value>
   </data>
-  <data name="TripDetails_TripNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_GroupNamePlaceholder" xml:space="preserve">
     <value>Weekend al mare, soggiorno in baita...</value>
   </data>
-  <data name="TripDetails_CurrencyLabel" xml:space="preserve">
+  <data name="GroupDetails_CurrencyLabel" xml:space="preserve">
     <value>Valuta</value>
   </data>
-  <data name="TripDetails_PeopleSection" xml:space="preserve">
+  <data name="GroupDetails_PeopleSection" xml:space="preserve">
     <value>Persone</value>
   </data>
-  <data name="TripDetails_HouseholdHint" xml:space="preserve">
+  <data name="GroupDetails_HouseholdHint" xml:space="preserve">
     <value>Usa lo stesso nome di nucleo quando le persone devono saldare insieme.</value>
   </data>
-  <data name="TripDetails_NoPeopleTitle" xml:space="preserve">
+  <data name="GroupDetails_NoPeopleTitle" xml:space="preserve">
     <value>Ancora nessuna persona.</value>
   </data>
-  <data name="TripDetails_NoPeopleSubtitle" xml:space="preserve">
-    <value>Aggiungi almeno una persona prima di salvare il viaggio.</value>
+  <data name="GroupDetails_NoPeopleSubtitle" xml:space="preserve">
+    <value>Aggiungi almeno una persona prima di salvare il gruppo.</value>
   </data>
-  <data name="TripDetails_AddPersonSection" xml:space="preserve">
+  <data name="GroupDetails_AddPersonSection" xml:space="preserve">
     <value>Aggiungi persona</value>
   </data>
-  <data name="TripDetails_PersonNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_PersonNamePlaceholder" xml:space="preserve">
     <value>Nome</value>
   </data>
-  <data name="TripDetails_HouseholdNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_HouseholdNamePlaceholder" xml:space="preserve">
     <value>Nucleo o famiglia (facoltativo)</value>
   </data>
-  <data name="TripDetails_AddPersonButton" xml:space="preserve">
+  <data name="GroupDetails_AddPersonButton" xml:space="preserve">
     <value>Aggiungi persona</value>
   </data>
-  <data name="TripDetails_CreateButton" xml:space="preserve">
-    <value>Crea viaggio</value>
+  <data name="GroupDetails_CreateButton" xml:space="preserve">
+    <value>Crea gruppo</value>
   </data>
-  <data name="TripDetails_SaveButton" xml:space="preserve">
-    <value>Salva viaggio</value>
+  <data name="GroupDetails_SaveButton" xml:space="preserve">
+    <value>Salva gruppo</value>
   </data>
-  <data name="TripDetails_ExportButton" xml:space="preserve">
-    <value>Esporta viaggio</value>
+  <data name="GroupDetails_ExportButton" xml:space="preserve">
+    <value>Esporta gruppo</value>
   </data>
-  <data name="TripDetails_SettlesOnOwn" xml:space="preserve">
+  <data name="GroupDetails_SettlesOnOwn" xml:space="preserve">
     <value>Salda per conto proprio</value>
   </data>
-  <data name="TripDetails_PersonAdded" xml:space="preserve">
+  <data name="GroupDetails_PersonAdded" xml:space="preserve">
     <value>Persona aggiunta.</value>
   </data>
-  <data name="TripDetails_PersonAddedNew" xml:space="preserve">
-    <value>Persona aggiunta al nuovo viaggio.</value>
+  <data name="GroupDetails_PersonAddedNew" xml:space="preserve">
+    <value>Persona aggiunta al nuovo gruppo.</value>
   </data>
-  <data name="TripDetails_Remove" xml:space="preserve">
+  <data name="GroupDetails_Remove" xml:space="preserve">
     <value>Rimuovi</value>
   </data>
   <data name="AddEvent_Title" xml:space="preserve">
@@ -215,7 +215,7 @@
     <value>Registra pagamento</value>
   </data>
   <data name="RecordPayment_Subtitle" xml:space="preserve">
-    <value>Cattura un pagamento reale e mantieni il diario del viaggio aggiornato.</value>
+    <value>Cattura un pagamento reale e mantieni il diario del gruppo aggiornato.</value>
   </data>
   <data name="RecordPayment_WhoPaid" xml:space="preserve">
     <value>Chi ha pagato?</value>
@@ -236,7 +236,7 @@
     <value>Annulla</value>
   </data>
   <data name="Export_DialogTitle" xml:space="preserve">
-    <value>Esporta questo viaggio</value>
+    <value>Esporta questo gruppo</value>
   </data>
   <data name="Export_JsonOption" xml:space="preserve">
     <value>Snapshot JSON</value>
@@ -248,7 +248,7 @@
     <value>Riepilogo PDF</value>
   </data>
   <data name="Export_ShareTitle" xml:space="preserve">
-    <value>Esporta viaggio</value>
+    <value>Esporta gruppo</value>
   </data>
   <data name="Export_Failed" xml:space="preserve">
     <value>Esportazione fallita. {0}</value>
@@ -268,11 +268,11 @@
   <data name="Validation_PersonNameRequired" xml:space="preserve">
     <value>Il nome è obbligatorio.</value>
   </data>
-  <data name="Validation_TripNotFound" xml:space="preserve">
-    <value>Viaggio non trovato.</value>
+  <data name="Validation_GroupNotFound" xml:space="preserve">
+    <value>Gruppo non trovato.</value>
   </data>
-  <data name="Validation_TripNameRequired" xml:space="preserve">
-    <value>Il nome del viaggio è obbligatorio.</value>
+  <data name="Validation_GroupNameRequired" xml:space="preserve">
+    <value>Il nome del gruppo è obbligatorio.</value>
   </data>
   <data name="Validation_SelectCurrency" xml:space="preserve">
     <value>Scegli una valuta.</value>
@@ -300,6 +300,169 @@
   </data>
   <data name="Language_SystemDefault" xml:space="preserve">
     <value>Predefinita di sistema</value>
+  </data>
+
+  <!-- GroupDetails missing keys -->
+  <data name="GroupDetails_ArchiveButton" xml:space="preserve">
+    <value>Archivia gruppo</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmTitle" xml:space="preserve">
+    <value>Archiviare questo gruppo?</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmMessage" xml:space="preserve">
+    <value>Questo gruppo verrà spostato nell'archivio. Puoi ancora leggerlo ed esportarlo, ma non potrai aggiungere nuovi eventi.</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmYes" xml:space="preserve">
+    <value>Archivia</value>
+  </data>
+  <data name="GroupDetails_ArchivedStatus" xml:space="preserve">
+    <value>Questo gruppo è archiviato e in sola lettura.</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCategoryLabel" xml:space="preserve">
+    <value>Quota di consumo</value>
+  </data>
+  <data name="GroupDetails_ConsumptionFull" xml:space="preserve">
+    <value>Intera</value>
+  </data>
+  <data name="GroupDetails_ConsumptionHalf" xml:space="preserve">
+    <value>Metà</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCustom" xml:space="preserve">
+    <value>Peso personalizzato</value>
+  </data>
+  <data name="GroupDetails_CustomWeightPlaceholder" xml:space="preserve">
+    <value>es. 0,5</value>
+  </data>
+  <data name="GroupDetails_PersonIsOwner" xml:space="preserve">
+    <value>Pagante</value>
+  </data>
+  <data name="GroupDetails_PersonIsDependent" xml:space="preserve">
+    <value>Dipendente</value>
+  </data>
+  <data name="GroupDetails_AddPersonHint" xml:space="preserve">
+    <value>Aggiungi prima il pagante. Poi aggiungi i familiari con lo stesso nome di nucleo — salderanno sotto il pagante.</value>
+  </data>
+  <data name="Validation_InvalidCustomWeight" xml:space="preserve">
+    <value>Inserisci un peso personalizzato valido (es. 0,5).</value>
+  </data>
+  <data name="Validation_CustomWeightRequiredForCustomCategory" xml:space="preserve">
+    <value>Il peso personalizzato è obbligatorio quando il consumo è impostato su Personalizzato.</value>
+  </data>
+
+  <!-- Archived groups -->
+  <data name="Archived_Title" xml:space="preserve">
+    <value>Gruppi archiviati</value>
+  </data>
+  <data name="Archived_Subtitle" xml:space="preserve">
+    <value>Questi gruppi sono chiusi. Puoi ancora leggerli ed esportarli.</value>
+  </data>
+  <data name="Archived_EmptyTitle" xml:space="preserve">
+    <value>Ancora nessun gruppo archiviato.</value>
+  </data>
+  <data name="Archived_EmptySubtitle" xml:space="preserve">
+    <value>I gruppi archiviati appaiono qui.</value>
+  </data>
+  <data name="Archived_Badge" xml:space="preserve">
+    <value>Archiviato</value>
+  </data>
+
+  <!-- Validation (service-level) -->
+  <data name="Validation_CurrencyRequired" xml:space="preserve">
+    <value>La valuta è obbligatoria.</value>
+  </data>
+  <data name="Validation_EachPersonNeedsName" xml:space="preserve">
+    <value>Ogni persona ha bisogno di un nome.</value>
+  </data>
+
+  <!-- Mapper / presentation sentences -->
+  <data name="Mapper_Person" xml:space="preserve">
+    <value>Persona</value>
+  </data>
+  <data name="Mapper_Everyone" xml:space="preserve">
+    <value>tutti</value>
+  </data>
+  <data name="Mapper_And" xml:space="preserve">
+    <value>e</value>
+  </data>
+  <data name="Mapper_SplitEqual" xml:space="preserve">
+    <value>Diviso equamente tra {0}</value>
+  </data>
+  <data name="Mapper_SplitWeighted" xml:space="preserve">
+    <value>Ponderato tra {0}</value>
+  </data>
+  <data name="Mapper_SplitByPercentage" xml:space="preserve">
+    <value>Condiviso per percentuali tra {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmounts" xml:space="preserve">
+    <value>Condiviso con importi personalizzati tra {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmountsOnly" xml:space="preserve">
+    <value>Importi personalizzati per {0}</value>
+  </data>
+  <data name="Mapper_HouseholdOf" xml:space="preserve">
+    <value>Nucleo di {0}</value>
+  </data>
+  <data name="Mapper_PaymentTitle" xml:space="preserve">
+    <value>Pagamento</value>
+  </data>
+  <data name="Mapper_PaymentPrimaryText" xml:space="preserve">
+    <value>{0} ha pagato {1}</value>
+  </data>
+  <data name="Mapper_PaymentSecondaryText" xml:space="preserve">
+    <value>Pagamento registrato</value>
+  </data>
+  <data name="Mapper_ActivityExpenseTitle" xml:space="preserve">
+    <value>{0} ha aggiunto {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentTitle" xml:space="preserve">
+    <value>{0} ha pagato {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentDetail" xml:space="preserve">
+    <value>Pagamento registrato</value>
+  </data>
+  <data name="Mapper_BalanceOwes" xml:space="preserve">
+    <value>{0} deve a {1}</value>
+  </data>
+  <data name="Mapper_BalanceEvenNow" xml:space="preserve">
+    <value>Al momento tutti sono pari.</value>
+  </data>
+  <data name="Mapper_SummaryReadyToGo" xml:space="preserve">
+    <value>{0} persone pronte</value>
+  </data>
+  <data name="Mapper_SummaryEvents" xml:space="preserve">
+    <value>{0} persone · {1} eventi</value>
+  </data>
+  <data name="Mapper_Today" xml:space="preserve">
+    <value>Oggi</value>
+  </data>
+  <data name="Mapper_Yesterday" xml:space="preserve">
+    <value>Ieri</value>
+  </data>
+
+  <!-- Group status labels -->
+  <data name="Status_CurrentGroup" xml:space="preserve">
+    <value>Gruppo corrente</value>
+  </data>
+  <data name="Status_OpenedOn" xml:space="preserve">
+    <value>Aperto {0}</value>
+  </data>
+  <data name="Status_RecentActivity" xml:space="preserve">
+    <value>Attività recente {0}</value>
+  </data>
+  <data name="Status_ReadyForFirstEvent" xml:space="preserve">
+    <value>Pronto per il primo evento</value>
+  </data>
+  <data name="Status_AddFirstEvent" xml:space="preserve">
+    <value>Aggiungi il primo evento.</value>
+  </data>
+  <data name="Status_Settled" xml:space="preserve">
+    <value>Saldato.</value>
+  </data>
+  <data name="Status_DefaultGroupName" xml:space="preserve">
+    <value>Gruppo</value>
+  </data>
+  <data name="Status_Household" xml:space="preserve">
+    <value>Nucleo</value>
   </data>
 
 </root>

--- a/src/LuSplit.App/Resources/Localization/AppResources.pt.resx
+++ b/src/LuSplit.App/Resources/Localization/AppResources.pt.resx
@@ -17,135 +17,135 @@
     <value>Atividade</value>
   </data>
   <data name="Activity_Subtitle" xml:space="preserve">
-    <value>Eventos recentes da sua viagem atual.</value>
+    <value>Eventos recentes do seu grupo atual.</value>
   </data>
   <data name="Activity_EmptyTitle" xml:space="preserve">
     <value>Nada aqui ainda.</value>
   </data>
   <data name="Activity_EmptySubtitle" xml:space="preserve">
-    <value>Abra uma viagem e adicione o primeiro evento.</value>
+    <value>Abra um grupo e adicione o primeiro evento.</value>
   </data>
-  <data name="Trips_Title" xml:space="preserve">
-    <value>Viagens</value>
+  <data name="Groups_Title" xml:space="preserve">
+    <value>Grupos</value>
   </data>
-  <data name="Trips_Subtitle" xml:space="preserve">
-    <value>Continue de onde parou ou inicie uma nova viagem.</value>
+  <data name="Groups_Subtitle" xml:space="preserve">
+    <value>Continue de onde parou ou inicie um novo grupo.</value>
   </data>
-  <data name="Trips_EmptyTitle" xml:space="preserve">
-    <value>Nenhuma viagem ainda.</value>
+  <data name="Groups_EmptyTitle" xml:space="preserve">
+    <value>Nenhum grupo ainda.</value>
   </data>
-  <data name="Trips_EmptySubtitle" xml:space="preserve">
-    <value>Crie a sua primeira viagem e comece a adicionar eventos.</value>
+  <data name="Groups_EmptySubtitle" xml:space="preserve">
+    <value>Crie o seu primeiro grupo e comece a adicionar eventos.</value>
   </data>
-  <data name="Trips_Open" xml:space="preserve">
+  <data name="Groups_Open" xml:space="preserve">
     <value>Abrir</value>
   </data>
-  <data name="Trips_Details" xml:space="preserve">
+  <data name="Groups_Details" xml:space="preserve">
     <value>Detalhes</value>
   </data>
-  <data name="Trips_NewTrip" xml:space="preserve">
-    <value>+ Nova viagem</value>
+  <data name="Groups_NewGroup" xml:space="preserve">
+    <value>+ Novo grupo</value>
   </data>
-  <data name="Trips_Active" xml:space="preserve">
+  <data name="Groups_Active" xml:space="preserve">
     <value>Ativo</value>
   </data>
-  <data name="Trip_Title" xml:space="preserve">
+  <data name="Group_Title" xml:space="preserve">
     <value>Viagem</value>
   </data>
-  <data name="Trip_DetailsButton" xml:space="preserve">
+  <data name="Group_DetailsButton" xml:space="preserve">
     <value>Detalhes</value>
   </data>
-  <data name="Trip_WhoOwesWhat" xml:space="preserve">
+  <data name="Group_WhoOwesWhat" xml:space="preserve">
     <value>Quem deve o quê</value>
   </data>
-  <data name="Trip_EveryoneEven" xml:space="preserve">
+  <data name="Group_EveryoneEven" xml:space="preserve">
     <value>Todos estão quites agora.</value>
   </data>
-  <data name="Trip_SettleUp" xml:space="preserve">
+  <data name="Group_SettleUp" xml:space="preserve">
     <value>Acertar</value>
   </data>
-  <data name="Trip_Events" xml:space="preserve">
+  <data name="Group_Events" xml:space="preserve">
     <value>Eventos</value>
   </data>
-  <data name="Trip_EmptyTitle" xml:space="preserve">
-    <value>A sua viagem acabou de começar.</value>
+  <data name="Group_EmptyTitle" xml:space="preserve">
+    <value>O seu grupo está pronto.</value>
   </data>
-  <data name="Trip_EmptySubtitle" xml:space="preserve">
+  <data name="Group_EmptySubtitle" xml:space="preserve">
     <value>Adicione a primeira despesa abaixo.</value>
   </data>
-  <data name="Trip_AddExpense" xml:space="preserve">
+  <data name="Group_AddExpense" xml:space="preserve">
     <value>+ Adicionar despesa</value>
   </data>
-  <data name="Trip_RecordPayment" xml:space="preserve">
+  <data name="Group_RecordPayment" xml:space="preserve">
     <value>Registar pagamento</value>
   </data>
-  <data name="TripDetails_Title" xml:space="preserve">
-    <value>Detalhes da viagem</value>
+  <data name="GroupDetails_Title" xml:space="preserve">
+    <value>Detalhes do grupo</value>
   </data>
-  <data name="TripDetails_PageTitleCreate" xml:space="preserve">
-    <value>Nova viagem</value>
+  <data name="GroupDetails_PageTitleCreate" xml:space="preserve">
+    <value>Novo grupo</value>
   </data>
-  <data name="TripDetails_PageTitleEdit" xml:space="preserve">
-    <value>Detalhes da viagem</value>
+  <data name="GroupDetails_PageTitleEdit" xml:space="preserve">
+    <value>Detalhes do grupo</value>
   </data>
-  <data name="TripDetails_SubtitleCreate" xml:space="preserve">
-    <value>Configure a viagem uma vez, depois comece a adicionar eventos.</value>
+  <data name="GroupDetails_SubtitleCreate" xml:space="preserve">
+    <value>Configure o grupo uma vez, depois comece a adicionar eventos.</value>
   </data>
-  <data name="TripDetails_SubtitleEdit" xml:space="preserve">
-    <value>Atualize o essencial e mantenha a viagem pronta para o próximo evento.</value>
+  <data name="GroupDetails_SubtitleEdit" xml:space="preserve">
+    <value>Atualize o essencial e mantenha o grupo pronto para o próximo evento.</value>
   </data>
-  <data name="TripDetails_TripNameLabel" xml:space="preserve">
-    <value>Nome da viagem</value>
+  <data name="GroupDetails_GroupNameLabel" xml:space="preserve">
+    <value>Nome do grupo</value>
   </data>
-  <data name="TripDetails_TripNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_GroupNamePlaceholder" xml:space="preserve">
     <value>Fim de semana na praia, estadia na cabana...</value>
   </data>
-  <data name="TripDetails_CurrencyLabel" xml:space="preserve">
+  <data name="GroupDetails_CurrencyLabel" xml:space="preserve">
     <value>Moeda</value>
   </data>
-  <data name="TripDetails_PeopleSection" xml:space="preserve">
+  <data name="GroupDetails_PeopleSection" xml:space="preserve">
     <value>Pessoas</value>
   </data>
-  <data name="TripDetails_HouseholdHint" xml:space="preserve">
+  <data name="GroupDetails_HouseholdHint" xml:space="preserve">
     <value>Use o mesmo nome de lar quando as pessoas devem acertar juntas.</value>
   </data>
-  <data name="TripDetails_NoPeopleTitle" xml:space="preserve">
+  <data name="GroupDetails_NoPeopleTitle" xml:space="preserve">
     <value>Nenhuma pessoa ainda.</value>
   </data>
-  <data name="TripDetails_NoPeopleSubtitle" xml:space="preserve">
-    <value>Adicione pelo menos uma pessoa antes de guardar a viagem.</value>
+  <data name="GroupDetails_NoPeopleSubtitle" xml:space="preserve">
+    <value>Adicione pelo menos uma pessoa antes de guardar o grupo.</value>
   </data>
-  <data name="TripDetails_AddPersonSection" xml:space="preserve">
+  <data name="GroupDetails_AddPersonSection" xml:space="preserve">
     <value>Adicionar pessoa</value>
   </data>
-  <data name="TripDetails_PersonNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_PersonNamePlaceholder" xml:space="preserve">
     <value>Nome</value>
   </data>
-  <data name="TripDetails_HouseholdNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_HouseholdNamePlaceholder" xml:space="preserve">
     <value>Lar ou família (opcional)</value>
   </data>
-  <data name="TripDetails_AddPersonButton" xml:space="preserve">
+  <data name="GroupDetails_AddPersonButton" xml:space="preserve">
     <value>Adicionar pessoa</value>
   </data>
-  <data name="TripDetails_CreateButton" xml:space="preserve">
-    <value>Criar viagem</value>
+  <data name="GroupDetails_CreateButton" xml:space="preserve">
+    <value>Criar grupo</value>
   </data>
-  <data name="TripDetails_SaveButton" xml:space="preserve">
-    <value>Guardar viagem</value>
+  <data name="GroupDetails_SaveButton" xml:space="preserve">
+    <value>Guardar grupo</value>
   </data>
-  <data name="TripDetails_ExportButton" xml:space="preserve">
-    <value>Exportar viagem</value>
+  <data name="GroupDetails_ExportButton" xml:space="preserve">
+    <value>Exportar grupo</value>
   </data>
-  <data name="TripDetails_SettlesOnOwn" xml:space="preserve">
+  <data name="GroupDetails_SettlesOnOwn" xml:space="preserve">
     <value>Paga por conta própria</value>
   </data>
-  <data name="TripDetails_PersonAdded" xml:space="preserve">
+  <data name="GroupDetails_PersonAdded" xml:space="preserve">
     <value>Pessoa adicionada.</value>
   </data>
-  <data name="TripDetails_PersonAddedNew" xml:space="preserve">
-    <value>Pessoa adicionada à nova viagem.</value>
+  <data name="GroupDetails_PersonAddedNew" xml:space="preserve">
+    <value>Pessoa adicionada ao novo grupo.</value>
   </data>
-  <data name="TripDetails_Remove" xml:space="preserve">
+  <data name="GroupDetails_Remove" xml:space="preserve">
     <value>Remover</value>
   </data>
   <data name="AddEvent_Title" xml:space="preserve">
@@ -215,7 +215,7 @@
     <value>Registar pagamento</value>
   </data>
   <data name="RecordPayment_Subtitle" xml:space="preserve">
-    <value>Capture um pagamento real e mantenha a cronologia da viagem honesta.</value>
+    <value>Capture um pagamento real e mantenha a cronologia do grupo honesta.</value>
   </data>
   <data name="RecordPayment_WhoPaid" xml:space="preserve">
     <value>Quem pagou?</value>
@@ -236,7 +236,7 @@
     <value>Cancelar</value>
   </data>
   <data name="Export_DialogTitle" xml:space="preserve">
-    <value>Exportar esta viagem</value>
+    <value>Exportar este grupo</value>
   </data>
   <data name="Export_JsonOption" xml:space="preserve">
     <value>Instantâneo JSON</value>
@@ -248,7 +248,7 @@
     <value>Resumo PDF</value>
   </data>
   <data name="Export_ShareTitle" xml:space="preserve">
-    <value>Exportar viagem</value>
+    <value>Exportar grupo</value>
   </data>
   <data name="Export_Failed" xml:space="preserve">
     <value>Falha na exportação. {0}</value>
@@ -268,11 +268,11 @@
   <data name="Validation_PersonNameRequired" xml:space="preserve">
     <value>O nome é obrigatório.</value>
   </data>
-  <data name="Validation_TripNotFound" xml:space="preserve">
-    <value>Viagem não encontrada.</value>
+  <data name="Validation_GroupNotFound" xml:space="preserve">
+    <value>Grupo não encontrado.</value>
   </data>
-  <data name="Validation_TripNameRequired" xml:space="preserve">
-    <value>O nome da viagem é obrigatório.</value>
+  <data name="Validation_GroupNameRequired" xml:space="preserve">
+    <value>O nome do grupo é obrigatório.</value>
   </data>
   <data name="Validation_SelectCurrency" xml:space="preserve">
     <value>Escolha uma moeda.</value>
@@ -300,6 +300,169 @@
   </data>
   <data name="Language_SystemDefault" xml:space="preserve">
     <value>Padrão do sistema</value>
+  </data>
+
+  <!-- GroupDetails missing keys -->
+  <data name="GroupDetails_ArchiveButton" xml:space="preserve">
+    <value>Arquivar grupo</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmTitle" xml:space="preserve">
+    <value>Arquivar este grupo?</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmMessage" xml:space="preserve">
+    <value>Este grupo será movido para o arquivo. Ainda pode lê-lo e exportá-lo, mas não poderá adicionar novos eventos.</value>
+  </data>
+  <data name="GroupDetails_ArchiveConfirmYes" xml:space="preserve">
+    <value>Arquivar</value>
+  </data>
+  <data name="GroupDetails_ArchivedStatus" xml:space="preserve">
+    <value>Este grupo está arquivado e é apenas de leitura.</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCategoryLabel" xml:space="preserve">
+    <value>Quota de consumo</value>
+  </data>
+  <data name="GroupDetails_ConsumptionFull" xml:space="preserve">
+    <value>Total</value>
+  </data>
+  <data name="GroupDetails_ConsumptionHalf" xml:space="preserve">
+    <value>Metade</value>
+  </data>
+  <data name="GroupDetails_ConsumptionCustom" xml:space="preserve">
+    <value>Peso personalizado</value>
+  </data>
+  <data name="GroupDetails_CustomWeightPlaceholder" xml:space="preserve">
+    <value>ex. 0,5</value>
+  </data>
+  <data name="GroupDetails_PersonIsOwner" xml:space="preserve">
+    <value>Pagador</value>
+  </data>
+  <data name="GroupDetails_PersonIsDependent" xml:space="preserve">
+    <value>Dependente</value>
+  </data>
+  <data name="GroupDetails_AddPersonHint" xml:space="preserve">
+    <value>Adicione primeiro o pagador. Depois adicione familiares com o mesmo nome de lar — saldarão sob o pagador.</value>
+  </data>
+  <data name="Validation_InvalidCustomWeight" xml:space="preserve">
+    <value>Introduza um peso personalizado válido (ex. 0,5).</value>
+  </data>
+  <data name="Validation_CustomWeightRequiredForCustomCategory" xml:space="preserve">
+    <value>O peso personalizado é obrigatório quando o consumo está definido como Personalizado.</value>
+  </data>
+
+  <!-- Archived groups -->
+  <data name="Archived_Title" xml:space="preserve">
+    <value>Grupos arquivados</value>
+  </data>
+  <data name="Archived_Subtitle" xml:space="preserve">
+    <value>Estes grupos estão fechados. Ainda pode lê-los e exportá-los.</value>
+  </data>
+  <data name="Archived_EmptyTitle" xml:space="preserve">
+    <value>Ainda não há grupos arquivados.</value>
+  </data>
+  <data name="Archived_EmptySubtitle" xml:space="preserve">
+    <value>Os grupos arquivados aparecem aqui.</value>
+  </data>
+  <data name="Archived_Badge" xml:space="preserve">
+    <value>Arquivado</value>
+  </data>
+
+  <!-- Validation (service-level) -->
+  <data name="Validation_CurrencyRequired" xml:space="preserve">
+    <value>A moeda é obrigatória.</value>
+  </data>
+  <data name="Validation_EachPersonNeedsName" xml:space="preserve">
+    <value>Cada pessoa precisa de um nome.</value>
+  </data>
+
+  <!-- Mapper / presentation sentences -->
+  <data name="Mapper_Person" xml:space="preserve">
+    <value>Pessoa</value>
+  </data>
+  <data name="Mapper_Everyone" xml:space="preserve">
+    <value>todos</value>
+  </data>
+  <data name="Mapper_And" xml:space="preserve">
+    <value>e</value>
+  </data>
+  <data name="Mapper_SplitEqual" xml:space="preserve">
+    <value>Dividido igualmente entre {0}</value>
+  </data>
+  <data name="Mapper_SplitWeighted" xml:space="preserve">
+    <value>Ponderado entre {0}</value>
+  </data>
+  <data name="Mapper_SplitByPercentage" xml:space="preserve">
+    <value>Partilhado por percentagens entre {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmounts" xml:space="preserve">
+    <value>Partilhado com montantes personalizados entre {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmountsOnly" xml:space="preserve">
+    <value>Montantes personalizados para {0}</value>
+  </data>
+  <data name="Mapper_HouseholdOf" xml:space="preserve">
+    <value>Lar de {0}</value>
+  </data>
+  <data name="Mapper_PaymentTitle" xml:space="preserve">
+    <value>Pagamento</value>
+  </data>
+  <data name="Mapper_PaymentPrimaryText" xml:space="preserve">
+    <value>{0} pagou a {1}</value>
+  </data>
+  <data name="Mapper_PaymentSecondaryText" xml:space="preserve">
+    <value>Pagamento registado</value>
+  </data>
+  <data name="Mapper_ActivityExpenseTitle" xml:space="preserve">
+    <value>{0} adicionou {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentTitle" xml:space="preserve">
+    <value>{0} pagou a {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentDetail" xml:space="preserve">
+    <value>Pagamento registado</value>
+  </data>
+  <data name="Mapper_BalanceOwes" xml:space="preserve">
+    <value>{0} deve a {1}</value>
+  </data>
+  <data name="Mapper_BalanceEvenNow" xml:space="preserve">
+    <value>Todos estão quites agora.</value>
+  </data>
+  <data name="Mapper_SummaryReadyToGo" xml:space="preserve">
+    <value>{0} pessoas prontas</value>
+  </data>
+  <data name="Mapper_SummaryEvents" xml:space="preserve">
+    <value>{0} pessoas · {1} eventos</value>
+  </data>
+  <data name="Mapper_Today" xml:space="preserve">
+    <value>Hoje</value>
+  </data>
+  <data name="Mapper_Yesterday" xml:space="preserve">
+    <value>Ontem</value>
+  </data>
+
+  <!-- Group status labels -->
+  <data name="Status_CurrentGroup" xml:space="preserve">
+    <value>Grupo atual</value>
+  </data>
+  <data name="Status_OpenedOn" xml:space="preserve">
+    <value>Aberto {0}</value>
+  </data>
+  <data name="Status_RecentActivity" xml:space="preserve">
+    <value>Atividade recente {0}</value>
+  </data>
+  <data name="Status_ReadyForFirstEvent" xml:space="preserve">
+    <value>Pronto para o primeiro evento</value>
+  </data>
+  <data name="Status_AddFirstEvent" xml:space="preserve">
+    <value>Adicione o primeiro evento.</value>
+  </data>
+  <data name="Status_Settled" xml:space="preserve">
+    <value>Acertado.</value>
+  </data>
+  <data name="Status_DefaultGroupName" xml:space="preserve">
+    <value>Grupo</value>
+  </data>
+  <data name="Status_Household" xml:space="preserve">
+    <value>Lar</value>
   </data>
 
 </root>

--- a/src/LuSplit.App/Resources/Localization/AppResources.resx
+++ b/src/LuSplit.App/Resources/Localization/AppResources.resx
@@ -18,183 +18,183 @@
     <value>Activity</value>
   </data>
   <data name="Activity_Subtitle" xml:space="preserve">
-    <value>Recent events from your current trip.</value>
+    <value>Recent events from your current group.</value>
   </data>
   <data name="Activity_EmptyTitle" xml:space="preserve">
     <value>Nothing here yet.</value>
   </data>
   <data name="Activity_EmptySubtitle" xml:space="preserve">
-    <value>Open a trip and add the first event.</value>
+    <value>Open a group and add the first event.</value>
   </data>
 
-  <!-- Trips (Home) -->
-  <data name="Trips_Title" xml:space="preserve">
-    <value>Trips</value>
+  <!-- Groups (Home) -->
+  <data name="Groups_Title" xml:space="preserve">
+    <value>Groups</value>
   </data>
-  <data name="Trips_ViewArchived" xml:space="preserve">
-    <value>View archived trips</value>
+  <data name="Groups_ViewArchived" xml:space="preserve">
+    <value>View archived groups</value>
   </data>
-  <data name="Trips_Subtitle" xml:space="preserve">
-    <value>Pick up where you left off or start a new trip.</value>
+  <data name="Groups_Subtitle" xml:space="preserve">
+    <value>Pick up where you left off or start a new group.</value>
   </data>
-  <data name="Trips_EmptyTitle" xml:space="preserve">
-    <value>No trips yet.</value>
+  <data name="Groups_EmptyTitle" xml:space="preserve">
+    <value>No groups yet.</value>
   </data>
-  <data name="Trips_EmptySubtitle" xml:space="preserve">
-    <value>Create your first trip and start adding events.</value>
+  <data name="Groups_EmptySubtitle" xml:space="preserve">
+    <value>Create your first group and start adding events.</value>
   </data>
-  <data name="Trips_Open" xml:space="preserve">
+  <data name="Groups_Open" xml:space="preserve">
     <value>Open</value>
   </data>
-  <data name="Trips_Details" xml:space="preserve">
+  <data name="Groups_Details" xml:space="preserve">
     <value>Details</value>
   </data>
-  <data name="Trips_NewTrip" xml:space="preserve">
-    <value>+ New trip</value>
+  <data name="Groups_NewGroup" xml:space="preserve">
+    <value>+ New group</value>
   </data>
-  <data name="Trips_Active" xml:space="preserve">
+  <data name="Groups_Active" xml:space="preserve">
     <value>Active</value>
   </data>
 
-  <!-- Trip timeline -->
-  <data name="Trip_Title" xml:space="preserve">
-    <value>Trip</value>
+  <!-- Group timeline -->
+  <data name="Group_Title" xml:space="preserve">
+    <value>Group</value>
   </data>
-  <data name="Trip_DetailsButton" xml:space="preserve">
+  <data name="Group_DetailsButton" xml:space="preserve">
     <value>Details</value>
   </data>
-  <data name="Trip_WhoOwesWhat" xml:space="preserve">
+  <data name="Group_WhoOwesWhat" xml:space="preserve">
     <value>Who owes what</value>
   </data>
-  <data name="Trip_EveryoneEven" xml:space="preserve">
+  <data name="Group_EveryoneEven" xml:space="preserve">
     <value>Everyone is even right now.</value>
   </data>
-  <data name="Trip_SettleUp" xml:space="preserve">
+  <data name="Group_SettleUp" xml:space="preserve">
     <value>Settle up</value>
   </data>
-  <data name="Trip_Events" xml:space="preserve">
+  <data name="Group_Events" xml:space="preserve">
     <value>Events</value>
   </data>
-  <data name="Trip_EmptyTitle" xml:space="preserve">
-    <value>Your trip just started.</value>
+  <data name="Group_EmptyTitle" xml:space="preserve">
+    <value>Your group is ready.</value>
   </data>
-  <data name="Trip_EmptySubtitle" xml:space="preserve">
+  <data name="Group_EmptySubtitle" xml:space="preserve">
     <value>Add the first expense below.</value>
   </data>
-  <data name="Trip_AddExpense" xml:space="preserve">
+  <data name="Group_AddExpense" xml:space="preserve">
     <value>+ Add expense</value>
   </data>
-  <data name="Trip_RecordPayment" xml:space="preserve">
+  <data name="Group_RecordPayment" xml:space="preserve">
     <value>Record payment</value>
   </data>
 
-  <!-- Trip Details -->
-  <data name="TripDetails_Title" xml:space="preserve">
-    <value>Trip details</value>
+  <!-- Group Details -->
+  <data name="GroupDetails_Title" xml:space="preserve">
+    <value>Group details</value>
   </data>
-  <data name="TripDetails_PageTitleCreate" xml:space="preserve">
-    <value>New trip</value>
+  <data name="GroupDetails_PageTitleCreate" xml:space="preserve">
+    <value>New group</value>
   </data>
-  <data name="TripDetails_PageTitleEdit" xml:space="preserve">
-    <value>Trip details</value>
+  <data name="GroupDetails_PageTitleEdit" xml:space="preserve">
+    <value>Group details</value>
   </data>
-  <data name="TripDetails_SubtitleCreate" xml:space="preserve">
-    <value>Set up the trip once, then start adding events.</value>
+  <data name="GroupDetails_SubtitleCreate" xml:space="preserve">
+    <value>Set up the group once, then start adding events.</value>
   </data>
-  <data name="TripDetails_SubtitleEdit" xml:space="preserve">
-    <value>Update the basics and keep the trip ready for the next event.</value>
+  <data name="GroupDetails_SubtitleEdit" xml:space="preserve">
+    <value>Update the basics and keep the group ready for the next event.</value>
   </data>
-  <data name="TripDetails_TripNameLabel" xml:space="preserve">
-    <value>Trip name</value>
+  <data name="GroupDetails_GroupNameLabel" xml:space="preserve">
+    <value>Group name</value>
   </data>
-  <data name="TripDetails_TripNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_GroupNamePlaceholder" xml:space="preserve">
     <value>Beach weekend, cabin stay...</value>
   </data>
-  <data name="TripDetails_CurrencyLabel" xml:space="preserve">
+  <data name="GroupDetails_CurrencyLabel" xml:space="preserve">
     <value>Currency</value>
   </data>
-  <data name="TripDetails_PeopleSection" xml:space="preserve">
+  <data name="GroupDetails_PeopleSection" xml:space="preserve">
     <value>People</value>
   </data>
-  <data name="TripDetails_HouseholdHint" xml:space="preserve">
+  <data name="GroupDetails_HouseholdHint" xml:space="preserve">
     <value>Leave blank to settle independently. Enter the same household name for family members who should settle together under one payer.</value>
   </data>
-  <data name="TripDetails_NoPeopleTitle" xml:space="preserve">
+  <data name="GroupDetails_NoPeopleTitle" xml:space="preserve">
     <value>No people yet.</value>
   </data>
-  <data name="TripDetails_NoPeopleSubtitle" xml:space="preserve">
-    <value>Add at least one person before saving the trip.</value>
+  <data name="GroupDetails_NoPeopleSubtitle" xml:space="preserve">
+    <value>Add at least one person before saving the group.</value>
   </data>
-  <data name="TripDetails_AddPersonSection" xml:space="preserve">
+  <data name="GroupDetails_AddPersonSection" xml:space="preserve">
     <value>Add person</value>
   </data>
-  <data name="TripDetails_PersonNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_PersonNamePlaceholder" xml:space="preserve">
     <value>Alex</value>
   </data>
-  <data name="TripDetails_HouseholdNamePlaceholder" xml:space="preserve">
+  <data name="GroupDetails_HouseholdNamePlaceholder" xml:space="preserve">
     <value>Household or family (optional)</value>
   </data>
-  <data name="TripDetails_AddPersonButton" xml:space="preserve">
+  <data name="GroupDetails_AddPersonButton" xml:space="preserve">
     <value>Add person</value>
   </data>
-  <data name="TripDetails_CreateButton" xml:space="preserve">
-    <value>Create trip</value>
+  <data name="GroupDetails_CreateButton" xml:space="preserve">
+    <value>Create group</value>
   </data>
-  <data name="TripDetails_SaveButton" xml:space="preserve">
-    <value>Save trip</value>
+  <data name="GroupDetails_SaveButton" xml:space="preserve">
+    <value>Save group</value>
   </data>
-  <data name="TripDetails_ExportButton" xml:space="preserve">
-    <value>Export trip</value>
+  <data name="GroupDetails_ExportButton" xml:space="preserve">
+    <value>Export group</value>
   </data>
-  <data name="TripDetails_ArchiveButton" xml:space="preserve">
-    <value>Archive trip</value>
+  <data name="GroupDetails_ArchiveButton" xml:space="preserve">
+    <value>Archive group</value>
   </data>
-  <data name="TripDetails_ArchiveConfirmTitle" xml:space="preserve">
-    <value>Archive this trip?</value>
+  <data name="GroupDetails_ArchiveConfirmTitle" xml:space="preserve">
+    <value>Archive this group?</value>
   </data>
-  <data name="TripDetails_ArchiveConfirmMessage" xml:space="preserve">
-    <value>This trip will be moved to archive. You can still read and export it, but won't be able to add new events.</value>
+  <data name="GroupDetails_ArchiveConfirmMessage" xml:space="preserve">
+    <value>This group will be moved to archive. You can still read and export it, but won't be able to add new events.</value>
   </data>
-  <data name="TripDetails_ArchiveConfirmYes" xml:space="preserve">
+  <data name="GroupDetails_ArchiveConfirmYes" xml:space="preserve">
     <value>Archive</value>
   </data>
-  <data name="TripDetails_ArchivedStatus" xml:space="preserve">
-    <value>This trip is archived and read-only.</value>
+  <data name="GroupDetails_ArchivedStatus" xml:space="preserve">
+    <value>This group is archived and read-only.</value>
   </data>
-  <data name="TripDetails_ConsumptionCategoryLabel" xml:space="preserve">
+  <data name="GroupDetails_ConsumptionCategoryLabel" xml:space="preserve">
     <value>Consumption share</value>
   </data>
-  <data name="TripDetails_ConsumptionFull" xml:space="preserve">
+  <data name="GroupDetails_ConsumptionFull" xml:space="preserve">
     <value>Full</value>
   </data>
-  <data name="TripDetails_ConsumptionHalf" xml:space="preserve">
+  <data name="GroupDetails_ConsumptionHalf" xml:space="preserve">
     <value>Half</value>
   </data>
-  <data name="TripDetails_ConsumptionCustom" xml:space="preserve">
+  <data name="GroupDetails_ConsumptionCustom" xml:space="preserve">
     <value>Custom weight</value>
   </data>
-  <data name="TripDetails_CustomWeightPlaceholder" xml:space="preserve">
+  <data name="GroupDetails_CustomWeightPlaceholder" xml:space="preserve">
     <value>e.g. 0.5</value>
   </data>
-  <data name="TripDetails_PersonIsOwner" xml:space="preserve">
+  <data name="GroupDetails_PersonIsOwner" xml:space="preserve">
     <value>Payer</value>
   </data>
-  <data name="TripDetails_PersonIsDependent" xml:space="preserve">
+  <data name="GroupDetails_PersonIsDependent" xml:space="preserve">
     <value>Dependent</value>
   </data>
-  <data name="TripDetails_AddPersonHint" xml:space="preserve">
+  <data name="GroupDetails_AddPersonHint" xml:space="preserve">
     <value>Add the payer first. Then add family members with the same household name — they will settle under the payer.</value>
   </data>
-  <data name="TripDetails_SettlesOnOwn" xml:space="preserve">
+  <data name="GroupDetails_SettlesOnOwn" xml:space="preserve">
     <value>Settles on their own</value>
   </data>
-  <data name="TripDetails_PersonAdded" xml:space="preserve">
+  <data name="GroupDetails_PersonAdded" xml:space="preserve">
     <value>Person added.</value>
   </data>
-  <data name="TripDetails_PersonAddedNew" xml:space="preserve">
-    <value>Person added to the new trip.</value>
+  <data name="GroupDetails_PersonAddedNew" xml:space="preserve">
+    <value>Person added to the new group.</value>
   </data>
-  <data name="TripDetails_Remove" xml:space="preserve">
+  <data name="GroupDetails_Remove" xml:space="preserve">
     <value>Remove</value>
   </data>
 
@@ -270,7 +270,7 @@
     <value>Record payment</value>
   </data>
   <data name="RecordPayment_Subtitle" xml:space="preserve">
-    <value>Capture a real payment and keep the trip timeline honest.</value>
+    <value>Capture a real payment and keep the group timeline honest.</value>
   </data>
   <data name="RecordPayment_WhoPaid" xml:space="preserve">
     <value>Who paid?</value>
@@ -295,7 +295,7 @@
 
   <!-- Export -->
   <data name="Export_DialogTitle" xml:space="preserve">
-    <value>Export this trip</value>
+    <value>Export this group</value>
   </data>
   <data name="Export_JsonOption" xml:space="preserve">
     <value>JSON snapshot</value>
@@ -307,7 +307,7 @@
     <value>PDF summary</value>
   </data>
   <data name="Export_ShareTitle" xml:space="preserve">
-    <value>Export trip</value>
+    <value>Export group</value>
   </data>
   <data name="Export_Failed" xml:space="preserve">
     <value>Export failed. {0}</value>
@@ -329,11 +329,11 @@
   <data name="Validation_PersonNameRequired" xml:space="preserve">
     <value>Person name is required.</value>
   </data>
-  <data name="Validation_TripNotFound" xml:space="preserve">
-    <value>Trip not found.</value>
+  <data name="Validation_GroupNotFound" xml:space="preserve">
+    <value>Group not found.</value>
   </data>
-  <data name="Validation_TripNameRequired" xml:space="preserve">
-    <value>Trip name is required.</value>
+  <data name="Validation_GroupNameRequired" xml:space="preserve">
+    <value>Group name is required.</value>
   </data>
   <data name="Validation_SelectCurrency" xml:space="preserve">
     <value>Choose a currency.</value>
@@ -348,18 +348,18 @@
     <value>Custom weight is required when consumption is set to Custom.</value>
   </data>
 
-  <!-- Archived trips -->
+  <!-- Archived groups -->
   <data name="Archived_Title" xml:space="preserve">
-    <value>Archived trips</value>
+    <value>Archived groups</value>
   </data>
   <data name="Archived_Subtitle" xml:space="preserve">
-    <value>These trips are closed. You can still read and export them.</value>
+    <value>These groups are closed. You can still read and export them.</value>
   </data>
   <data name="Archived_EmptyTitle" xml:space="preserve">
-    <value>No archived trips yet.</value>
+    <value>No archived groups yet.</value>
   </data>
   <data name="Archived_EmptySubtitle" xml:space="preserve">
-    <value>Archived trips appear here.</value>
+    <value>Archived groups appear here.</value>
   </data>
   <data name="Archived_Badge" xml:space="preserve">
     <value>Archived</value>
@@ -386,6 +386,105 @@
   </data>
   <data name="Language_SystemDefault" xml:space="preserve">
     <value>System Default</value>
+  </data>
+
+  <!-- Validation (service-level) -->
+  <data name="Validation_CurrencyRequired" xml:space="preserve">
+    <value>Currency is required.</value>
+  </data>
+  <data name="Validation_EachPersonNeedsName" xml:space="preserve">
+    <value>Each person needs a name.</value>
+  </data>
+
+  <!-- Mapper / presentation sentences -->
+  <data name="Mapper_Person" xml:space="preserve">
+    <value>Person</value>
+  </data>
+  <data name="Mapper_Everyone" xml:space="preserve">
+    <value>everyone</value>
+  </data>
+  <data name="Mapper_And" xml:space="preserve">
+    <value>and</value>
+  </data>
+  <data name="Mapper_SplitEqual" xml:space="preserve">
+    <value>Shared equally between {0}</value>
+  </data>
+  <data name="Mapper_SplitWeighted" xml:space="preserve">
+    <value>Weighted between {0}</value>
+  </data>
+  <data name="Mapper_SplitByPercentage" xml:space="preserve">
+    <value>Shared by percentages between {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmounts" xml:space="preserve">
+    <value>Shared with custom amounts between {0}</value>
+  </data>
+  <data name="Mapper_SplitCustomAmountsOnly" xml:space="preserve">
+    <value>Custom amounts for {0}</value>
+  </data>
+  <data name="Mapper_HouseholdOf" xml:space="preserve">
+    <value>{0}'s household</value>
+  </data>
+  <data name="Mapper_PaymentTitle" xml:space="preserve">
+    <value>Payment</value>
+  </data>
+  <data name="Mapper_PaymentPrimaryText" xml:space="preserve">
+    <value>{0} paid {1}</value>
+  </data>
+  <data name="Mapper_PaymentSecondaryText" xml:space="preserve">
+    <value>Recorded payment</value>
+  </data>
+  <data name="Mapper_ActivityExpenseTitle" xml:space="preserve">
+    <value>{0} added {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentTitle" xml:space="preserve">
+    <value>{0} paid {1}</value>
+  </data>
+  <data name="Mapper_ActivityPaymentDetail" xml:space="preserve">
+    <value>Payment recorded</value>
+  </data>
+  <data name="Mapper_BalanceOwes" xml:space="preserve">
+    <value>{0} owes {1}</value>
+  </data>
+  <data name="Mapper_BalanceEvenNow" xml:space="preserve">
+    <value>Everyone is even right now.</value>
+  </data>
+  <data name="Mapper_SummaryReadyToGo" xml:space="preserve">
+    <value>{0} people ready to go</value>
+  </data>
+  <data name="Mapper_SummaryEvents" xml:space="preserve">
+    <value>{0} people · {1} events</value>
+  </data>
+  <data name="Mapper_Today" xml:space="preserve">
+    <value>Today</value>
+  </data>
+  <data name="Mapper_Yesterday" xml:space="preserve">
+    <value>Yesterday</value>
+  </data>
+
+  <!-- Group status labels -->
+  <data name="Status_CurrentGroup" xml:space="preserve">
+    <value>Current group</value>
+  </data>
+  <data name="Status_OpenedOn" xml:space="preserve">
+    <value>Opened {0}</value>
+  </data>
+  <data name="Status_RecentActivity" xml:space="preserve">
+    <value>Recent activity {0}</value>
+  </data>
+  <data name="Status_ReadyForFirstEvent" xml:space="preserve">
+    <value>Ready for the first event</value>
+  </data>
+  <data name="Status_AddFirstEvent" xml:space="preserve">
+    <value>Add the first event.</value>
+  </data>
+  <data name="Status_Settled" xml:space="preserve">
+    <value>Settled.</value>
+  </data>
+  <data name="Status_DefaultGroupName" xml:space="preserve">
+    <value>Group</value>
+  </data>
+  <data name="Status_Household" xml:space="preserve">
+    <value>Household</value>
   </data>
 
 </root>

--- a/src/LuSplit.App/Services/AppDataService.cs
+++ b/src/LuSplit.App/Services/AppDataService.cs
@@ -1,6 +1,7 @@
 using LuSplit.Application.Commands;
 using LuSplit.Application.Models;
 using LuSplit.Application.Queries;
+using LuSplit.App.Resources.Localization;
 using LuSplit.Domain.Entities;
 using LuSplit.Domain.Split;
 using LuSplit.Infrastructure.Client;
@@ -50,15 +51,15 @@ public sealed class AppDataService : IAsyncDisposable
     }
 
     public async Task<GroupOverviewModel> GetOverviewAsync()
-        => (await GetTripWorkspaceAsync()).Overview;
+        => (await GetGroupWorkspaceAsync()).Overview;
 
     public async Task<GroupOverviewModel> GetOverviewAsync(string groupId)
-        => (await GetTripWorkspaceAsync(groupId)).Overview;
+        => (await GetGroupWorkspaceAsync(groupId)).Overview;
 
-    public async Task<TripWorkspaceModel> GetTripWorkspaceAsync()
-        => await GetTripWorkspaceAsync(await GetSelectedGroupIdAsync());
+    public async Task<GroupWorkspaceModel> GetGroupWorkspaceAsync()
+        => await GetGroupWorkspaceAsync(await GetSelectedGroupIdAsync());
 
-    public async Task<TripWorkspaceModel> GetTripWorkspaceAsync(string groupId)
+    public async Task<GroupWorkspaceModel> GetGroupWorkspaceAsync(string groupId)
     {
         var infra = await GetInfraAsync();
         var overview = await new GetGroupOverviewUseCase(
@@ -68,10 +69,10 @@ public sealed class AppDataService : IAsyncDisposable
             infra.ExpenseRepository,
             infra.TransferRepository).ExecuteAsync(groupId);
 
-        var metadata = await GetTripMetadataAsync(groupId);
-        return new TripWorkspaceModel(
+        var metadata = await GetGroupMetadataAsync(groupId);
+        return new GroupWorkspaceModel(
             groupId,
-            ResolveTripName(metadata.Name, overview),
+            ResolveGroupName(metadata.Name, overview),
             overview,
             await GetExpenseIconsAsync(groupId),
             metadata.LastOpenedUtc);
@@ -83,83 +84,83 @@ public sealed class AppDataService : IAsyncDisposable
         return overview.Participants;
     }
 
-    public async Task<IReadOnlyList<TripListItemModel>> GetTripsAsync()
+    public async Task<IReadOnlyList<GroupListItemModel>> GetGroupsAsync()
     {
         var selectedGroupId = await GetSelectedGroupIdAsync();
         var groupIds = await ListGroupIdsAsync();
-        var trips = new List<TripListItemModel>(groupIds.Count);
+        var groups = new List<GroupListItemModel>(groupIds.Count);
 
         foreach (var groupId in groupIds)
         {
-            var workspace = await GetTripWorkspaceAsync(groupId);
-            // Archived trips are hidden from the active list.
+            var workspace = await GetGroupWorkspaceAsync(groupId);
+            // Archived groups are hidden from the active list.
             if (workspace.Overview.Group.Closed) continue;
             var lastActivity = GetLastActivity(workspace.Overview);
             var rankDate = workspace.LastOpenedUtc ?? lastActivity ?? DateTimeOffset.MinValue;
-            trips.Add(new TripListItemModel(
+            groups.Add(new GroupListItemModel(
                 groupId,
-                workspace.TripName,
+                workspace.GroupName,
                 workspace.Overview.Group.Currency,
                 string.Equals(groupId, selectedGroupId, StringComparison.Ordinal),
-                TripPresentationMapper.BuildTripSummary(workspace.Overview),
-                TripPresentationMapper.BuildBalancePreview(workspace.Overview, 1).FirstOrDefault() ?? "Add the first event.",
-                BuildTripStatusText(string.Equals(groupId, selectedGroupId, StringComparison.Ordinal), workspace.LastOpenedUtc, lastActivity),
+                GroupPresentationMapper.BuildGroupSummary(workspace.Overview),
+                GroupPresentationMapper.BuildBalancePreview(workspace.Overview, 1).FirstOrDefault() ?? AppResources.Status_AddFirstEvent,
+                BuildGroupStatusText(string.Equals(groupId, selectedGroupId, StringComparison.Ordinal), workspace.LastOpenedUtc, lastActivity),
                 rankDate));
         }
 
-        return trips
-            .OrderByDescending(trip => trip.IsCurrent)
-            .ThenByDescending(trip => trip.RankDate)
-            .ThenBy(trip => trip.Name, StringComparer.OrdinalIgnoreCase)
+        return groups
+            .OrderByDescending(group => group.IsCurrent)
+            .ThenByDescending(group => group.RankDate)
+            .ThenBy(group => group.Name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
     }
 
-    public async Task<IReadOnlyList<TripListItemModel>> GetArchivedTripsAsync()
+    public async Task<IReadOnlyList<GroupListItemModel>> GetArchivedGroupsAsync()
     {
         var groupIds = await ListGroupIdsAsync();
-        var trips = new List<TripListItemModel>(groupIds.Count);
+        var groups = new List<GroupListItemModel>(groupIds.Count);
 
         foreach (var groupId in groupIds)
         {
-            var workspace = await GetTripWorkspaceAsync(groupId);
+            var workspace = await GetGroupWorkspaceAsync(groupId);
             if (!workspace.Overview.Group.Closed) continue;
             var lastActivity = GetLastActivity(workspace.Overview);
             var rankDate = workspace.LastOpenedUtc ?? lastActivity ?? DateTimeOffset.MinValue;
-            trips.Add(new TripListItemModel(
+            groups.Add(new GroupListItemModel(
                 groupId,
-                workspace.TripName,
+                workspace.GroupName,
                 workspace.Overview.Group.Currency,
                 false,
-                TripPresentationMapper.BuildTripSummary(workspace.Overview),
-                TripPresentationMapper.BuildBalancePreview(workspace.Overview, 1).FirstOrDefault() ?? "Settled.",
+                GroupPresentationMapper.BuildGroupSummary(workspace.Overview),
+                GroupPresentationMapper.BuildBalancePreview(workspace.Overview, 1).FirstOrDefault() ?? AppResources.Status_Settled,
                 string.Empty,
                 rankDate));
         }
 
-        return trips
+        return groups
             .OrderByDescending(t => t.RankDate)
             .ThenBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
     }
 
-    public async Task<TripDetailsModel> GetTripDetailsAsync()
-        => await GetTripDetailsAsync(await GetSelectedGroupIdAsync());
+    public async Task<GroupDetailsModel> GetGroupDetailsAsync()
+        => await GetGroupDetailsAsync(await GetSelectedGroupIdAsync());
 
-    public async Task<TripDetailsModel> GetTripDetailsAsync(string groupId)
+    public async Task<GroupDetailsModel> GetGroupDetailsAsync(string groupId)
     {
-        var workspace = await GetTripWorkspaceAsync(groupId);
+        var workspace = await GetGroupWorkspaceAsync(groupId);
         var householdNames = BuildHouseholdLookup(workspace.Overview);
         var ownerIdsByUnit = workspace.Overview.EconomicUnits
             .ToDictionary(unit => unit.Id, unit => unit.OwnerParticipantId, StringComparer.Ordinal);
 
-        return new TripDetailsModel(
+        return new GroupDetailsModel(
             groupId,
-            workspace.TripName,
+            workspace.GroupName,
             workspace.Overview.Group.Currency,
             workspace.Overview.Group.Closed,
             workspace.Overview.Participants
                 .OrderBy(participant => participant.Name, StringComparer.OrdinalIgnoreCase)
-                .Select(participant => new TripMemberModel(
+                .Select(participant => new GroupMemberModel(
                     participant.Id,
                     participant.Name,
                     householdNames.TryGetValue(participant.EconomicUnitId, out var householdName) ? householdName : participant.Name,
@@ -170,13 +171,13 @@ public sealed class AppDataService : IAsyncDisposable
                 .ToArray());
     }
 
-    /// <summary>Archives a trip. Archived trips are read-only — the domain blocks new expenses and participants on closed groups.</summary>
-    public async Task ArchiveTripAsync(string groupId)
+    /// <summary>Archives a group. Archived groups are read-only — the domain blocks new expenses and participants on closed groups.</summary>
+    public async Task ArchiveGroupAsync(string groupId)
     {
         var infra = await GetInfraAsync();
         await new CloseGroupUseCase(infra.GroupRepository).ExecuteAsync(new CloseGroupInput(groupId));
 
-        // If the archived trip was the active selection, fall through to the next active trip.
+        // If the archived group was the active selection, fall through to the next active group.
         if (string.Equals(_selectedGroupId, groupId, StringComparison.Ordinal))
         {
             _selectedGroupId = null;
@@ -189,24 +190,24 @@ public sealed class AppDataService : IAsyncDisposable
     public EventDraftDefaults GetEventDraftDefaults()
         => new(_lastPaidByParticipantId, _lastParticipantIds);
 
-    public async Task SelectTripAsync(string groupId)
+    public async Task SelectGroupAsync(string groupId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
 
         _selectedGroupId = groupId.Trim();
         Preferences.Default.Set(SelectedGroupPreferenceKey, _selectedGroupId);
-        await TouchTripAsync(_selectedGroupId);
+        await TouchGroupAsync(_selectedGroupId);
         DataChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    public async Task<string> CreateTripAsync(string tripName, string currency, IReadOnlyList<TripDraftMember> members)
+    public async Task<string> CreateGroupAsync(string groupName, string currency, IReadOnlyList<GroupDraftMember> members)
     {
-        var normalizedName = NormalizeRequired(tripName, "Trip name is required.");
-        var normalizedCurrency = NormalizeRequired(currency, "Currency is required.").ToUpperInvariant();
+        var normalizedName = NormalizeRequired(groupName, AppResources.Validation_GroupNameRequired);
+        var normalizedCurrency = NormalizeRequired(currency, AppResources.Validation_CurrencyRequired).ToUpperInvariant();
 
         var memberDrafts = members
-            .Select(member => new TripDraftMember(
-                NormalizeRequired(member.Name, "Each person needs a name."),
+            .Select(member => new GroupDraftMember(
+                NormalizeRequired(member.Name, AppResources.Validation_EachPersonNeedsName),
                 NormalizeOptional(member.HouseholdName),
                 member.ConsumptionCategory,
                 member.CustomConsumptionWeight))
@@ -214,44 +215,44 @@ public sealed class AppDataService : IAsyncDisposable
 
         if (memberDrafts.Length == 0)
         {
-            throw new InvalidOperationException("Add at least one person.");
+            throw new InvalidOperationException(AppResources.Validation_AddAtLeastOnePerson);
         }
 
         var infra = await GetInfraAsync();
         var group = await new CreateGroupUseCase(infra.GroupRepository, _idGenerator)
             .ExecuteAsync(new CreateGroupInput(normalizedCurrency));
 
-        await SaveTripMetadataAsync(group.Id, normalizedName, DateTimeOffset.UtcNow);
+        await SaveGroupMetadataAsync(group.Id, normalizedName, DateTimeOffset.UtcNow);
         await AddMembersAsync(group.Id, memberDrafts);
-        await SelectTripAsync(group.Id);
+        await SelectGroupAsync(group.Id);
         return group.Id;
     }
 
-    public async Task UpdateTripAsync(string groupId, string tripName, string currency)
+    public async Task UpdateGroupAsync(string groupId, string groupName, string currency)
     {
-        var normalizedName = NormalizeRequired(tripName, "Trip name is required.");
-        var normalizedCurrency = NormalizeRequired(currency, "Currency is required.").ToUpperInvariant();
+        var normalizedName = NormalizeRequired(groupName, AppResources.Validation_GroupNameRequired);
+        var normalizedCurrency = NormalizeRequired(currency, AppResources.Validation_CurrencyRequired).ToUpperInvariant();
         var infra = await GetInfraAsync();
         var existing = await infra.GroupRepository.GetByIdAsync(groupId, CancellationToken.None)
-            ?? throw new InvalidOperationException("Trip not found.");
+            ?? throw new InvalidOperationException(AppResources.Validation_GroupNotFound);
 
         await infra.GroupRepository.SaveGroupAsync(existing with { Currency = normalizedCurrency }, CancellationToken.None);
 
-        var metadata = await GetTripMetadataAsync(groupId);
-        await SaveTripMetadataAsync(groupId, normalizedName, metadata.LastOpenedUtc);
+        var metadata = await GetGroupMetadataAsync(groupId);
+        await SaveGroupMetadataAsync(groupId, normalizedName, metadata.LastOpenedUtc);
         DataChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    public async Task AddTripMemberAsync(
+    public async Task AddGroupMemberAsync(
         string groupId,
         string personName,
         string? householdName,
         ConsumptionCategory consumptionCategory = ConsumptionCategory.Full,
         string? customConsumptionWeight = null)
     {
-        var normalizedName = NormalizeRequired(personName, "Person name is required.");
+        var normalizedName = NormalizeRequired(personName, AppResources.Validation_PersonNameRequired);
         var normalizedHouseholdName = NormalizeOptional(householdName);
-        await AddMembersAsync(groupId, new[] { new TripDraftMember(normalizedName, normalizedHouseholdName, consumptionCategory, customConsumptionWeight) });
+        await AddMembersAsync(groupId, new[] { new GroupDraftMember(normalizedName, normalizedHouseholdName, consumptionCategory, customConsumptionWeight) });
         DataChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -332,18 +333,18 @@ public sealed class AppDataService : IAsyncDisposable
         return (balances, settlement);
     }
 
-    public async Task<ExportFileResult> ExportTripAsync(string groupId, ExportFormat format)
+    public async Task<ExportFileResult> ExportGroupAsync(string groupId, ExportFormat format)
     {
-        var workspace = await GetTripWorkspaceAsync(groupId);
+        var workspace = await GetGroupWorkspaceAsync(groupId);
         var outputDir = FileSystem.CacheDirectory;
-        var dto = new ExportTripDto(
+        var dto = new ExportGroupDto(
             groupId,
-            workspace.TripName,
+            workspace.GroupName,
             DateTimeOffset.UtcNow.ToString("O"),
             workspace.Overview,
             outputDir);
 
-        var exporter = new TripExporterService();
+        var exporter = new GroupExporterService();
         return format switch
         {
             ExportFormat.Json => await exporter.ExportJsonAsync(dto),
@@ -377,7 +378,7 @@ public sealed class AppDataService : IAsyncDisposable
 
         using var command = infra.Db.CreateCommand();
         command.CommandText = @"
-CREATE TABLE IF NOT EXISTS trip_metadata (
+CREATE TABLE IF NOT EXISTS group_metadata (
   group_id TEXT PRIMARY KEY NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
   name TEXT NULL,
   last_opened_utc TEXT NULL
@@ -436,7 +437,7 @@ CREATE TABLE IF NOT EXISTS expense_ui_metadata (
             }),
             "Weekly staples"), CancellationToken.None);
 
-        await SaveTripMetadataAsync(DefaultGroupId, "Weekend trip", DateTimeOffset.UtcNow);
+        await SaveGroupMetadataAsync(DefaultGroupId, "Weekend group", DateTimeOffset.UtcNow);
     }
 
     private async Task<string> GetSelectedGroupIdAsync()
@@ -473,36 +474,36 @@ CREATE TABLE IF NOT EXISTS expense_ui_metadata (
         return groupIds;
     }
 
-    private async Task<TripMetadataRecord> GetTripMetadataAsync(string groupId)
+    private async Task<GroupMetadataRecord> GetGroupMetadataAsync(string groupId)
     {
         var infra = await GetInfraAsync();
 
         using var command = infra.Db.CreateCommand();
-        command.CommandText = "SELECT name, last_opened_utc FROM trip_metadata WHERE group_id = $groupId";
+        command.CommandText = "SELECT name, last_opened_utc FROM group_metadata WHERE group_id = $groupId";
         command.Parameters.AddWithValue("$groupId", groupId);
 
         using var reader = command.ExecuteReader();
         if (!reader.Read())
         {
-            return new TripMetadataRecord(null, null);
+            return new GroupMetadataRecord(null, null);
         }
 
-        return new TripMetadataRecord(
+        return new GroupMetadataRecord(
             reader.IsDBNull(0) ? null : reader.GetString(0),
             reader.IsDBNull(1) || !DateTimeOffset.TryParse(reader.GetString(1), out var lastOpenedUtc) ? null : lastOpenedUtc);
     }
 
-    private async Task SaveTripMetadataAsync(string groupId, string? name, DateTimeOffset? lastOpenedUtc)
+    private async Task SaveGroupMetadataAsync(string groupId, string? name, DateTimeOffset? lastOpenedUtc)
     {
         var infra = await GetInfraAsync();
 
         using var command = infra.Db.CreateCommand();
         command.CommandText = @"
-INSERT INTO trip_metadata (group_id, name, last_opened_utc)
+INSERT INTO group_metadata (group_id, name, last_opened_utc)
 VALUES ($groupId, $name, $lastOpenedUtc)
 ON CONFLICT(group_id) DO UPDATE SET
-  name = COALESCE(excluded.name, trip_metadata.name),
-  last_opened_utc = COALESCE(excluded.last_opened_utc, trip_metadata.last_opened_utc);";
+  name = COALESCE(excluded.name, group_metadata.name),
+  last_opened_utc = COALESCE(excluded.last_opened_utc, group_metadata.last_opened_utc);";
         command.Parameters.AddWithValue("$groupId", groupId);
         command.Parameters.AddWithValue("$name", (object?)name ?? DBNull.Value);
         command.Parameters.AddWithValue("$lastOpenedUtc", lastOpenedUtc?.ToString("O") ?? (object)DBNull.Value);
@@ -511,8 +512,8 @@ ON CONFLICT(group_id) DO UPDATE SET
         await Task.CompletedTask;
     }
 
-    private Task TouchTripAsync(string groupId)
-        => SaveTripMetadataAsync(groupId, null, DateTimeOffset.UtcNow);
+    private Task TouchGroupAsync(string groupId)
+        => SaveGroupMetadataAsync(groupId, null, DateTimeOffset.UtcNow);
 
     private async Task<IReadOnlyDictionary<string, string>> GetExpenseIconsAsync(string groupId)
     {
@@ -553,7 +554,7 @@ ON CONFLICT(expense_id) DO UPDATE SET
         await Task.CompletedTask;
     }
 
-    private async Task AddMembersAsync(string groupId, IReadOnlyList<TripDraftMember> members)
+    private async Task AddMembersAsync(string groupId, IReadOnlyList<GroupDraftMember> members)
     {
         var infra = await GetInfraAsync();
         var createEconomicUnit = new CreateEconomicUnitUseCase(infra.GroupRepository, infra.EconomicUnitRepository, _idGenerator);
@@ -605,11 +606,11 @@ ON CONFLICT(expense_id) DO UPDATE SET
                 ? unit.Name!
                 : participantsById.TryGetValue(unit.OwnerParticipantId, out var ownerName)
                     ? ownerName
-                    : "Household",
+                    : AppResources.Status_Household,
             StringComparer.Ordinal);
     }
 
-    private static string ResolveTripName(string? storedName, GroupOverviewModel overview)
+    private static string ResolveGroupName(string? storedName, GroupOverviewModel overview)
     {
         if (!string.IsNullOrWhiteSpace(storedName))
         {
@@ -624,36 +625,36 @@ ON CONFLICT(expense_id) DO UPDATE SET
 
         return participantNames.Length switch
         {
-            0 => "Trip",
+            0 => AppResources.Status_DefaultGroupName,
             1 => participantNames[0],
-            _ => string.Join(", ", participantNames.Take(participantNames.Length - 1)) + " and " + participantNames[^1]
+            _ => string.Join(", ", participantNames.Take(participantNames.Length - 1)) + " " + AppResources.Mapper_And + " " + participantNames[^1]
         };
     }
 
-    private static string BuildTripStatusText(bool isCurrent, DateTimeOffset? lastOpenedUtc, DateTimeOffset? lastActivityUtc)
+    private static string BuildGroupStatusText(bool isCurrent, DateTimeOffset? lastOpenedUtc, DateTimeOffset? lastActivityUtc)
     {
         if (isCurrent)
         {
-            return "Current trip";
+            return AppResources.Status_CurrentGroup;
         }
 
         if (lastOpenedUtc.HasValue)
         {
-            return $"Opened {TripPresentationMapper.DescribeDay(lastOpenedUtc.Value)}";
+            return string.Format(AppResources.Status_OpenedOn, GroupPresentationMapper.DescribeDay(lastOpenedUtc.Value));
         }
 
         if (lastActivityUtc.HasValue)
         {
-            return $"Recent activity {TripPresentationMapper.DescribeDay(lastActivityUtc.Value)}";
+            return string.Format(AppResources.Status_RecentActivity, GroupPresentationMapper.DescribeDay(lastActivityUtc.Value));
         }
 
-        return "Ready for the first event";
+        return AppResources.Status_ReadyForFirstEvent;
     }
 
     private static DateTimeOffset? GetLastActivity(GroupOverviewModel overview)
     {
-        var lastExpense = overview.Expenses.Select(expense => TripPresentationMapper.ParseDate(expense.Date));
-        var lastTransfer = overview.Transfers.Select(transfer => TripPresentationMapper.ParseDate(transfer.Date));
+        var lastExpense = overview.Expenses.Select(expense => GroupPresentationMapper.ParseDate(expense.Date));
+        var lastTransfer = overview.Transfers.Select(transfer => GroupPresentationMapper.ParseDate(transfer.Date));
         var latest = lastExpense.Concat(lastTransfer).DefaultIfEmpty(DateTimeOffset.MinValue).Max();
         return latest == DateTimeOffset.MinValue ? null : latest;
     }
@@ -689,14 +690,14 @@ ON CONFLICT(expense_id) DO UPDATE SET
 }
 
 public sealed record EventDraftDefaults(string? PaidByParticipantId, IReadOnlyList<string> ParticipantIds);
-public sealed record TripWorkspaceModel(
+public sealed record GroupWorkspaceModel(
     string GroupId,
-    string TripName,
+    string GroupName,
     GroupOverviewModel Overview,
     IReadOnlyDictionary<string, string> ExpenseIcons,
     DateTimeOffset? LastOpenedUtc);
 
-public sealed record TripListItemModel(
+public sealed record GroupListItemModel(
     string GroupId,
     string Name,
     string Currency,
@@ -706,14 +707,14 @@ public sealed record TripListItemModel(
     string StatusText,
     DateTimeOffset RankDate);
 
-public sealed record TripDetailsModel(
+public sealed record GroupDetailsModel(
     string GroupId,
-    string TripName,
+    string GroupName,
     string Currency,
     bool IsArchived,
-    IReadOnlyList<TripMemberModel> Members);
+    IReadOnlyList<GroupMemberModel> Members);
 
-public sealed record TripMemberModel(
+public sealed record GroupMemberModel(
     string ParticipantId,
     string Name,
     string HouseholdName,
@@ -721,10 +722,10 @@ public sealed record TripMemberModel(
     string ConsumptionCategory,
     string? CustomConsumptionWeight);
 
-public sealed record TripDraftMember(
+public sealed record GroupDraftMember(
     string Name,
     string? HouseholdName,
     ConsumptionCategory ConsumptionCategory = ConsumptionCategory.Full,
     string? CustomConsumptionWeight = null);
 
-sealed record TripMetadataRecord(string? Name, DateTimeOffset? LastOpenedUtc);
+sealed record GroupMetadataRecord(string? Name, DateTimeOffset? LastOpenedUtc);

--- a/src/LuSplit.App/Services/TripPresentationMapper.cs
+++ b/src/LuSplit.App/Services/TripPresentationMapper.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
+using LuSplit.App.Resources.Localization;
 using LuSplit.Application.Models;
 using LuSplit.Domain.Split;
 
@@ -33,7 +34,7 @@ public sealed record EventIconOptionViewModel(string Icon, string Label)
     public string DisplayText => $"{Icon} {Label}";
 }
 
-public static class TripPresentationMapper
+public static class GroupPresentationMapper
 {
     private static readonly EventIconOptionViewModel[] BuiltInEventIcons =
     {
@@ -79,14 +80,14 @@ public static class TripPresentationMapper
         var items = overview.Expenses
             .Select(expense => new ActivityEntryViewModel(
                 ResolveExpenseIcon(expense, expenseIcons),
-                $"{ResolveParticipantName(expense.PaidByParticipantId, participantsById)} added {expense.Title}",
+                string.Format(AppResources.Mapper_ActivityExpenseTitle, ResolveParticipantName(expense.PaidByParticipantId, participantsById), expense.Title),
                 DescribeExpense(expense, participantsById),
                 FormatMinor(expense.AmountMinor, currency),
                 ParseDate(expense.Date)))
             .Concat(overview.Transfers.Select(transfer => new ActivityEntryViewModel(
                 "💸",
-                $"{ResolveParticipantName(transfer.FromParticipantId, participantsById)} paid {ResolveParticipantName(transfer.ToParticipantId, participantsById)}",
-                "Payment recorded",
+                string.Format(AppResources.Mapper_ActivityPaymentTitle, ResolveParticipantName(transfer.FromParticipantId, participantsById), ResolveParticipantName(transfer.ToParticipantId, participantsById)),
+                AppResources.Mapper_ActivityPaymentDetail,
                 FormatMinor(transfer.AmountMinor, currency),
                 ParseDate(transfer.Date))))
             .OrderByDescending(item => item.SortDate)
@@ -106,7 +107,7 @@ public static class TripPresentationMapper
 
         return transfers
             .Select(transfer => new BalanceLineViewModel(
-                $"{ResolveBalanceEntityName(transfer.FromParticipantId, overview, mode)} owes {ResolveBalanceEntityName(transfer.ToParticipantId, overview, mode)}",
+                string.Format(AppResources.Mapper_BalanceOwes, ResolveBalanceEntityName(transfer.FromParticipantId, overview, mode), ResolveBalanceEntityName(transfer.ToParticipantId, overview, mode)),
                 FormatMinor(transfer.AmountMinor, overview.Group.Currency)))
             .ToArray();
     }
@@ -118,19 +119,19 @@ public static class TripPresentationMapper
             .Select(line => $"{line.Text} {line.AmountText}")
             .ToArray();
 
-        return lines.Length == 0 ? new[] { "Everyone is even right now." } : lines;
+        return lines.Length == 0 ? new[] { AppResources.Mapper_BalanceEvenNow } : lines;
     }
 
-    public static string BuildTripSummary(GroupOverviewModel overview)
+    public static string BuildGroupSummary(GroupOverviewModel overview)
     {
         var eventCount = overview.Summary.ExpenseCount + overview.Summary.TransferCount;
         return eventCount == 0
-            ? $"{overview.Summary.ParticipantCount} people ready to go"
-            : $"{overview.Summary.ParticipantCount} people • {eventCount} events";
+            ? string.Format(AppResources.Mapper_SummaryReadyToGo, overview.Summary.ParticipantCount)
+            : string.Format(AppResources.Mapper_SummaryEvents, overview.Summary.ParticipantCount, eventCount);
     }
 
     /// <summary>
-    /// Picks the settlement mode that best reflects the trip's participant structure.
+    /// Picks the settlement mode that best reflects the group's participant structure.
     /// When all participants have their own economic unit (no dependents), participant-level
     /// and owner-level settlement are identical — either works. When some participants are
     /// dependents (share an economic unit with another payer), owner mode aggregates their
@@ -161,7 +162,7 @@ public static class TripPresentationMapper
             ResolveExpenseIcon(expense, expenseIcons),
             expense.Title,
             FormatMinor(expense.AmountMinor, currency),
-            $"{ResolveParticipantName(expense.PaidByParticipantId, participantsById)} paid {FormatMinor(expense.AmountMinor, currency)}",
+            string.Format(AppResources.Mapper_PaymentPrimaryText, ResolveParticipantName(expense.PaidByParticipantId, participantsById), FormatMinor(expense.AmountMinor, currency)),
             DescribeExpense(expense, participantsById),
             DescribeDay(date),
             date);
@@ -175,10 +176,10 @@ public static class TripPresentationMapper
         var date = ParseDate(transfer.Date);
         return new TimelineEntryViewModel(
             "💸",
-            "Payment",
+            AppResources.Mapper_PaymentTitle,
             FormatMinor(transfer.AmountMinor, currency),
-            $"{ResolveParticipantName(transfer.FromParticipantId, participantsById)} paid {ResolveParticipantName(transfer.ToParticipantId, participantsById)}",
-            "Recorded payment",
+            string.Format(AppResources.Mapper_PaymentPrimaryText, ResolveParticipantName(transfer.FromParticipantId, participantsById), ResolveParticipantName(transfer.ToParticipantId, participantsById)),
+            AppResources.Mapper_PaymentSecondaryText,
             DescribeDay(date),
             date);
     }
@@ -201,22 +202,22 @@ public static class TripPresentationMapper
 
         if (expense.SplitDefinition.Components.OfType<RemainderSplitComponent>().Any(component => component.Mode == RemainderMode.Weight))
         {
-            return $"Weighted between {peopleText}";
+            return string.Format(AppResources.Mapper_SplitWeighted, peopleText);
         }
 
         if (expense.SplitDefinition.Components.OfType<RemainderSplitComponent>().Any(component => component.Mode == RemainderMode.Percent))
         {
-            return $"Shared by percentages between {peopleText}";
+            return string.Format(AppResources.Mapper_SplitByPercentage, peopleText);
         }
 
         if (expense.SplitDefinition.Components.OfType<FixedSplitComponent>().Any())
         {
             return expense.SplitDefinition.Components.OfType<RemainderSplitComponent>().Any()
-                ? $"Shared with custom amounts between {peopleText}"
-                : $"Custom amounts for {peopleText}";
+                ? string.Format(AppResources.Mapper_SplitCustomAmounts, peopleText)
+                : string.Format(AppResources.Mapper_SplitCustomAmountsOnly, peopleText);
         }
 
-        return $"Shared equally between {peopleText}";
+        return string.Format(AppResources.Mapper_SplitEqual, peopleText);
     }
 
     private static string ResolveExpenseIcon(ExpenseModel expense, IReadOnlyDictionary<string, string>? expenseIcons)
@@ -247,7 +248,7 @@ public static class TripPresentationMapper
             return unit.Name!;
         }
 
-        return $"{ResolveParticipantName(entityId, overview.Participants)}'s household";
+        return string.Format(AppResources.Mapper_HouseholdOf, ResolveParticipantName(entityId, overview.Participants));
     }
 
     private static string IconForEvent(string title)
@@ -305,10 +306,10 @@ public static class TripPresentationMapper
         => ResolveParticipantName(participantId, overview.Participants);
 
     private static string ResolveParticipantName(string participantId, IReadOnlyList<ParticipantModel> participants)
-        => participants.FirstOrDefault(participant => string.Equals(participant.Id, participantId, StringComparison.Ordinal))?.Name ?? "Person";
+        => participants.FirstOrDefault(participant => string.Equals(participant.Id, participantId, StringComparison.Ordinal))?.Name ?? AppResources.Mapper_Person;
 
     private static string ResolveParticipantName(string participantId, IReadOnlyDictionary<string, string> participantsById)
-        => participantsById.TryGetValue(participantId, out var name) ? name : "Person";
+        => participantsById.TryGetValue(participantId, out var name) ? name : AppResources.Mapper_Person;
 
     public static string DescribeDay(DateTimeOffset date)
     {
@@ -317,15 +318,15 @@ public static class TripPresentationMapper
 
         if (target == today)
         {
-            return "Today";
+            return AppResources.Mapper_Today;
         }
 
         if (target == today.AddDays(-1))
         {
-            return "Yesterday";
+            return AppResources.Mapper_Yesterday;
         }
 
-        return date.ToLocalTime().ToString("MMM d", CultureInfo.InvariantCulture);
+        return date.ToLocalTime().ToString("MMM d", CultureInfo.CurrentCulture);
     }
 
     public static DateTimeOffset ParseDate(string value)
@@ -337,7 +338,7 @@ public static class TripPresentationMapper
     {
         if (names.Count == 0)
         {
-            return "everyone";
+            return AppResources.Mapper_Everyone;
         }
 
         if (names.Count == 1)
@@ -345,12 +346,13 @@ public static class TripPresentationMapper
             return names[0];
         }
 
+        var andWord = AppResources.Mapper_And;
         if (names.Count == 2)
         {
-            return $"{names[0]} and {names[1]}";
+            return $"{names[0]} {andWord} {names[1]}";
         }
 
-        return $"{string.Join(", ", names.Take(names.Count - 1))} and {names[^1]}";
+        return $"{string.Join(", ", names.Take(names.Count - 1))} {andWord} {names[^1]}";
     }
 
     private static string FormatMinor(long minor, string currency)
@@ -365,7 +367,7 @@ public static class TripPresentationMapper
         };
 
         return string.IsNullOrEmpty(symbol)
-            ? string.Create(CultureInfo.InvariantCulture, $"{amount:0.00} {currency.ToUpperInvariant()}")
-            : string.Create(CultureInfo.InvariantCulture, $"{symbol}{amount:0.00}");
+            ? string.Create(CultureInfo.CurrentCulture, $"{amount:0.00} {currency.ToUpperInvariant()}")
+            : string.Create(CultureInfo.CurrentCulture, $"{symbol}{amount:0.00}");
     }
 }

--- a/src/LuSplit.Application/Models/ExportModels.cs
+++ b/src/LuSplit.Application/Models/ExportModels.cs
@@ -4,9 +4,9 @@ public enum ExportFormat { Json, Csv, Pdf }
 
 public sealed record ExportFileResult(string FilePath, string FileName, string MimeType);
 
-public sealed record ExportTripDto(
+public sealed record ExportGroupDto(
     string GroupId,
-    string TripName,
+    string GroupName,
     string ExportedAt,
     GroupOverviewModel Overview,
     string OutputDirectory);

--- a/src/LuSplit.Application/Ports/IGroupExporter.cs
+++ b/src/LuSplit.Application/Ports/IGroupExporter.cs
@@ -4,7 +4,7 @@ namespace LuSplit.Application.Ports;
 
 public interface IGroupExporter
 {
-    Task<ExportFileResult> ExportJsonAsync(ExportTripDto dto, CancellationToken ct = default);
-    Task<ExportFileResult> ExportCsvBundleAsync(ExportTripDto dto, CancellationToken ct = default);
-    Task<ExportFileResult> ExportPdfAsync(ExportTripDto dto, CancellationToken ct = default);
+    Task<ExportFileResult> ExportJsonAsync(ExportGroupDto dto, CancellationToken ct = default);
+    Task<ExportFileResult> ExportCsvBundleAsync(ExportGroupDto dto, CancellationToken ct = default);
+    Task<ExportFileResult> ExportPdfAsync(ExportGroupDto dto, CancellationToken ct = default);
 }

--- a/src/LuSplit.Infrastructure/Export/CsvTripExporter.cs
+++ b/src/LuSplit.Infrastructure/Export/CsvTripExporter.cs
@@ -5,11 +5,11 @@ using LuSplit.Application.Models;
 
 namespace LuSplit.Infrastructure.Export;
 
-internal sealed class CsvTripExporter
+internal sealed class CsvGroupExporter
 {
-    public async Task<ExportFileResult> ExportAsync(ExportTripDto dto, CancellationToken ct)
+    public async Task<ExportFileResult> ExportAsync(ExportGroupDto dto, CancellationToken ct)
     {
-        var slug = ExportFileNaming.Slug(dto.TripName, dto.ExportedAt);
+        var slug = ExportFileNaming.Slug(dto.GroupName, dto.ExportedAt);
         var fileName = $"{slug}-export.zip";
         var filePath = Path.Combine(dto.OutputDirectory, fileName);
 

--- a/src/LuSplit.Infrastructure/Export/ExportFileNaming.cs
+++ b/src/LuSplit.Infrastructure/Export/ExportFileNaming.cs
@@ -5,17 +5,17 @@ namespace LuSplit.Infrastructure.Export;
 
 internal static class ExportFileNaming
 {
-    public static string Slug(string tripName, string exportedAt)
+    public static string Slug(string groupName, string exportedAt)
     {
         var date = DateTimeOffset.TryParse(exportedAt, null,
             System.Globalization.DateTimeStyles.None, out var dt)
             ? dt.UtcDateTime.ToString("yyyy-MM-dd")
             : "export";
 
-        // Decompose accented chars (é → e + combining mark), strip non-alnum
-        var normalized = tripName.Normalize(NormalizationForm.FormD);
+        // Decompose accented chars (é → e + combining mark), sgroup non-alnum
+        var normalized = groupName.Normalize(NormalizationForm.FormD);
         var slug = Regex.Replace(normalized.ToLowerInvariant(), @"[^a-z0-9]+", "-").Trim('-');
         if (slug.Length > 40) slug = slug[..40].TrimEnd('-');
-        return string.IsNullOrEmpty(slug) ? $"trip-{date}" : $"{slug}-{date}";
+        return string.IsNullOrEmpty(slug) ? $"group-{date}" : $"{slug}-{date}";
     }
 }

--- a/src/LuSplit.Infrastructure/Export/JsonTripExporter.cs
+++ b/src/LuSplit.Infrastructure/Export/JsonTripExporter.cs
@@ -6,16 +6,16 @@ using LuSplit.Infrastructure.Sqlite;
 
 namespace LuSplit.Infrastructure.Export;
 
-internal sealed class JsonTripExporter
+internal sealed class JsonGroupExporter
 {
     private static readonly JsonSerializerOptions WriteOptions = new() { WriteIndented = true };
 
-    public async Task<ExportFileResult> ExportAsync(ExportTripDto dto, CancellationToken ct)
+    public async Task<ExportFileResult> ExportAsync(ExportGroupDto dto, CancellationToken ct)
     {
         var root = BuildRoot(dto);
         var json = JsonSerializer.Serialize(root, WriteOptions);
 
-        var slug = ExportFileNaming.Slug(dto.TripName, dto.ExportedAt);
+        var slug = ExportFileNaming.Slug(dto.GroupName, dto.ExportedAt);
         var fileName = $"{slug}.snapshot.json";
         var filePath = Path.Combine(dto.OutputDirectory, fileName);
 
@@ -24,13 +24,13 @@ internal sealed class JsonTripExporter
         return new ExportFileResult(filePath, fileName, "application/json");
     }
 
-    private static object BuildRoot(ExportTripDto dto)
+    private static object BuildRoot(ExportGroupDto dto)
     {
         var o = dto.Overview;
         return new
         {
             schemaVersion = SnapshotContract.Version,
-            tripName = dto.TripName,
+            groupName = dto.GroupName,
             exportedAt = dto.ExportedAt,
             group = new
             {

--- a/src/LuSplit.Infrastructure/Export/PdfTripExporter.cs
+++ b/src/LuSplit.Infrastructure/Export/PdfTripExporter.cs
@@ -3,14 +3,14 @@ using LuSplit.Application.Models;
 
 namespace LuSplit.Infrastructure.Export;
 
-internal sealed class PdfTripExporter
+internal sealed class PdfGroupExporter
 {
-    public async Task<ExportFileResult> ExportAsync(ExportTripDto dto, CancellationToken ct)
+    public async Task<ExportFileResult> ExportAsync(ExportGroupDto dto, CancellationToken ct)
     {
         var lines = BuildLines(dto);
         var pdfBytes = SimplePdfBuilder.Build(lines);
 
-        var slug = ExportFileNaming.Slug(dto.TripName, dto.ExportedAt);
+        var slug = ExportFileNaming.Slug(dto.GroupName, dto.ExportedAt);
         var fileName = $"{slug}-summary.pdf";
         var filePath = Path.Combine(dto.OutputDirectory, fileName);
 
@@ -18,7 +18,7 @@ internal sealed class PdfTripExporter
         return new ExportFileResult(filePath, fileName, "application/pdf");
     }
 
-    private static IReadOnlyList<PdfLine> BuildLines(ExportTripDto dto)
+    private static IReadOnlyList<PdfLine> BuildLines(ExportGroupDto dto)
     {
         var o = dto.Overview;
         var byId = o.Participants.ToDictionary(p => p.Id, p => p.Name, StringComparer.Ordinal);
@@ -26,7 +26,7 @@ internal sealed class PdfTripExporter
         var lines = new List<PdfLine>();
 
         // ── Header ──────────────────────────────────────────────
-        lines.Add(new PdfLine(dto.TripName, PdfLineStyle.Title));
+        lines.Add(new PdfLine(dto.GroupName, PdfLineStyle.Title));
         var exportDate = DateTimeOffset.TryParse(dto.ExportedAt, null,
             DateTimeStyles.None, out var dt)
             ? dt.UtcDateTime.ToString("MMMM d, yyyy", CultureInfo.InvariantCulture)

--- a/src/LuSplit.Infrastructure/Export/TripExporterService.cs
+++ b/src/LuSplit.Infrastructure/Export/TripExporterService.cs
@@ -3,18 +3,18 @@ using LuSplit.Application.Ports;
 
 namespace LuSplit.Infrastructure.Export;
 
-public sealed class TripExporterService : IGroupExporter
+public sealed class GroupExporterService : IGroupExporter
 {
-    private readonly JsonTripExporter _json = new();
-    private readonly CsvTripExporter _csv = new();
-    private readonly PdfTripExporter _pdf = new();
+    private readonly JsonGroupExporter _json = new();
+    private readonly CsvGroupExporter _csv = new();
+    private readonly PdfGroupExporter _pdf = new();
 
-    public Task<ExportFileResult> ExportJsonAsync(ExportTripDto dto, CancellationToken ct = default)
+    public Task<ExportFileResult> ExportJsonAsync(ExportGroupDto dto, CancellationToken ct = default)
         => _json.ExportAsync(dto, ct);
 
-    public Task<ExportFileResult> ExportCsvBundleAsync(ExportTripDto dto, CancellationToken ct = default)
+    public Task<ExportFileResult> ExportCsvBundleAsync(ExportGroupDto dto, CancellationToken ct = default)
         => _csv.ExportAsync(dto, ct);
 
-    public Task<ExportFileResult> ExportPdfAsync(ExportTripDto dto, CancellationToken ct = default)
+    public Task<ExportFileResult> ExportPdfAsync(ExportGroupDto dto, CancellationToken ct = default)
         => _pdf.ExportAsync(dto, ct);
 }

--- a/tests/LuSplit.Application.Tests/ArchiveTripFlowTests.cs
+++ b/tests/LuSplit.Application.Tests/ArchiveTripFlowTests.cs
@@ -14,10 +14,10 @@ namespace LuSplit.Application.Tests;
 /// "Closed" and "archived" are synonymous. A closed group is visible in the archived list
 /// and is read-only: the application layer blocks new expenses and participants on closed groups.
 /// </summary>
-public sealed class ArchiveTripFlowTests
+public sealed class ArchiveGroupFlowTests
 {
     [Fact]
-    public async Task ArchivingATripSetsClosedFlagOnGroup()
+    public async Task ArchivingAGroupSetsClosedFlagOnGroup()
     {
         var repos = new InMemoryQueryRepositories();
         repos.Groups.Add(new Group("g1", "USD", false));
@@ -29,7 +29,7 @@ public sealed class ArchiveTripFlowTests
     }
 
     [Fact]
-    public async Task AddingParticipantToArchivedTripIsRejected()
+    public async Task AddingParticipantToArchivedGroupIsRejected()
     {
         var repos = new InMemoryQueryRepositories();
         repos.Groups.Add(new Group("g1", "USD", true)); // already archived
@@ -44,7 +44,7 @@ public sealed class ArchiveTripFlowTests
     }
 
     [Fact]
-    public async Task AddingEconomicUnitToArchivedTripIsRejected()
+    public async Task AddingEconomicUnitToArchivedGroupIsRejected()
     {
         var repos = new InMemoryQueryRepositories();
         repos.Groups.Add(new Group("g1", "USD", true));
@@ -58,9 +58,9 @@ public sealed class ArchiveTripFlowTests
     }
 
     [Fact]
-    public async Task ArchivedTripGroupOverviewIsStillReadable()
+    public async Task ArchivedGroupGroupOverviewIsStillReadable()
     {
-        // Archived trips can be read (for export, inspection); the group remains in the repository.
+        // Archived groups can be read (for export, inspection); the group remains in the repository.
         var repos = new InMemoryQueryRepositories();
         repos.Groups.Add(new Group("g1", "USD", true));
         repos.EconomicUnits.Add(new EconomicUnit("u1", "g1", "p1"));
@@ -73,7 +73,7 @@ public sealed class ArchiveTripFlowTests
     }
 
     [Fact]
-    public async Task ArchivingAlreadyArchivedTripIsIdempotent()
+    public async Task ArchivingAlreadyArchivedGroupIsIdempotent()
     {
         var repos = new InMemoryQueryRepositories();
         repos.Groups.Add(new Group("g1", "USD", false));

--- a/tests/LuSplit.Infrastructure.Tests/ExportTests.cs
+++ b/tests/LuSplit.Infrastructure.Tests/ExportTests.cs
@@ -15,7 +15,7 @@ public sealed class ExportTests
     public async Task ExportJson_ContainsAllExpectedTopLevelFields()
     {
         var dto = await CreateTestDto();
-        var exporter = new TripExporterService();
+        var exporter = new GroupExporterService();
 
         var result = await exporter.ExportJsonAsync(dto);
 
@@ -26,7 +26,7 @@ public sealed class ExportTests
         using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(result.FilePath));
         var root = doc.RootElement;
         Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
-        Assert.Equal("Test Trip", root.GetProperty("tripName").GetString());
+        Assert.Equal("Test Group", root.GetProperty("groupName").GetString());
         Assert.Equal(2, root.GetProperty("participants").GetArrayLength());
         Assert.Equal(1, root.GetProperty("expenses").GetArrayLength());
         Assert.Equal(0, root.GetProperty("transfers").GetArrayLength());
@@ -37,7 +37,7 @@ public sealed class ExportTests
     {
         var dto = await CreateTestDto(); // expense amountMinor = 1000
 
-        var result = await new TripExporterService().ExportJsonAsync(dto);
+        var result = await new GroupExporterService().ExportJsonAsync(dto);
 
         using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(result.FilePath));
         var expense = doc.RootElement.GetProperty("expenses")[0];
@@ -45,11 +45,11 @@ public sealed class ExportTests
     }
 
     [Fact]
-    public async Task ExportJson_FileNameIsSlugifiedTripName()
+    public async Task ExportJson_FileNameIsSlugifiedGroupName()
     {
         var dto = await CreateTestDto("Weekend in Paris!");
 
-        var result = await new TripExporterService().ExportJsonAsync(dto);
+        var result = await new GroupExporterService().ExportJsonAsync(dto);
 
         Assert.Contains("weekend-in-paris", result.FileName, StringComparison.OrdinalIgnoreCase);
         Assert.EndsWith(".snapshot.json", result.FileName);
@@ -60,7 +60,7 @@ public sealed class ExportTests
     {
         var dto = await CreateTestDto();
 
-        var result = await new TripExporterService().ExportCsvBundleAsync(dto);
+        var result = await new GroupExporterService().ExportCsvBundleAsync(dto);
 
         Assert.True(File.Exists(result.FilePath));
         Assert.Equal("application/zip", result.MimeType);
@@ -79,7 +79,7 @@ public sealed class ExportTests
     {
         var dto = await CreateTestDto();
 
-        var result = await new TripExporterService().ExportCsvBundleAsync(dto);
+        var result = await new GroupExporterService().ExportCsvBundleAsync(dto);
 
         using var zip = ZipFile.OpenRead(result.FilePath);
         var entry = zip.GetEntry("expenses.csv")!;
@@ -96,7 +96,7 @@ public sealed class ExportTests
     {
         var dto = await CreateTestDto(); // expense amountMinor = 1000 → "10.00"
 
-        var result = await new TripExporterService().ExportCsvBundleAsync(dto);
+        var result = await new GroupExporterService().ExportCsvBundleAsync(dto);
 
         using var zip = ZipFile.OpenRead(result.FilePath);
         var entry = zip.GetEntry("expenses.csv")!;
@@ -112,7 +112,7 @@ public sealed class ExportTests
     {
         var dto = await CreateTestDto();
 
-        var result = await new TripExporterService().ExportCsvBundleAsync(dto);
+        var result = await new GroupExporterService().ExportCsvBundleAsync(dto);
 
         using var zip = ZipFile.OpenRead(result.FilePath);
         var entry = zip.GetEntry("members.csv")!;
@@ -128,7 +128,7 @@ public sealed class ExportTests
     {
         var dto = await CreateTestDto();
 
-        var result = await new TripExporterService().ExportPdfAsync(dto);
+        var result = await new GroupExporterService().ExportPdfAsync(dto);
 
         Assert.True(File.Exists(result.FilePath));
         Assert.Equal("application/pdf", result.MimeType);
@@ -140,24 +140,24 @@ public sealed class ExportTests
     }
 
     [Fact]
-    public async Task ExportPdf_ContainsTripNameInContent()
+    public async Task ExportPdf_ContainsGroupNameInContent()
     {
-        var dto = await CreateTestDto("My Mediterranean Trip");
+        var dto = await CreateTestDto("My Mediterranean Group");
 
         var bytes = await File.ReadAllBytesAsync(
-            (await new TripExporterService().ExportPdfAsync(dto)).FilePath);
+            (await new GroupExporterService().ExportPdfAsync(dto)).FilePath);
 
-        // Trip name must appear in the PDF content stream (Latin-1 encoded)
+        // Group name must appear in the PDF content stream (Latin-1 encoded)
         var raw = System.Text.Encoding.Latin1.GetString(bytes);
-        Assert.Contains("My Mediterranean Trip", raw);
+        Assert.Contains("My Mediterranean Group", raw);
     }
 
     [Fact]
-    public async Task ExportPdf_EmptyTripShowsAllSettledMessage()
+    public async Task ExportPdf_EmptyGroupShowsAllSettledMessage()
     {
-        var dto = await CreateEmptyTripDto();
+        var dto = await CreateEmptyGroupDto();
         var bytes = await File.ReadAllBytesAsync(
-            (await new TripExporterService().ExportPdfAsync(dto)).FilePath);
+            (await new GroupExporterService().ExportPdfAsync(dto)).FilePath);
 
         var raw = System.Text.Encoding.Latin1.GetString(bytes);
         Assert.Contains("even", raw, StringComparison.OrdinalIgnoreCase);
@@ -165,7 +165,7 @@ public sealed class ExportTests
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
-    private static async Task<ExportTripDto> CreateTestDto(string tripName = "Test Trip")
+    private static async Task<ExportGroupDto> CreateTestDto(string groupName = "Test Group")
     {
         using var infra = await InfraLocalSqlite.CreateAsync();
 
@@ -195,10 +195,10 @@ public sealed class ExportTests
         var outputDir = Path.Combine(Path.GetTempPath(), $"lusplit-export-{Guid.NewGuid():N}");
         Directory.CreateDirectory(outputDir);
 
-        return new ExportTripDto("g-exp", tripName, "2026-03-14T10:00:00.000Z", overview, outputDir);
+        return new ExportGroupDto("g-exp", groupName, "2026-03-14T10:00:00.000Z", overview, outputDir);
     }
 
-    private static async Task<ExportTripDto> CreateEmptyTripDto()
+    private static async Task<ExportGroupDto> CreateEmptyGroupDto()
     {
         using var infra = await InfraLocalSqlite.CreateAsync();
 
@@ -216,6 +216,6 @@ public sealed class ExportTests
         var outputDir = Path.Combine(Path.GetTempPath(), $"lusplit-export-{Guid.NewGuid():N}");
         Directory.CreateDirectory(outputDir);
 
-        return new ExportTripDto("g-empty", "Empty Trip", "2026-03-14T10:00:00.000Z", overview, outputDir);
+        return new ExportGroupDto("g-empty", "Empty Group", "2026-03-14T10:00:00.000Z", overview, outputDir);
     }
 }

--- a/tests/LuSplit.Infrastructure.Tests/InfrastructureParityTests.cs
+++ b/tests/LuSplit.Infrastructure.Tests/InfrastructureParityTests.cs
@@ -115,7 +115,7 @@ public sealed class InfrastructureParityTests
     }
 
     [Fact]
-    public async Task SqliteExportImportRoundTripPreservesBalancesAndSettlement()
+    public async Task SqliteExportImportRoundGroupPreservesBalancesAndSettlement()
     {
         using var source = await InfraLocalSqlite.CreateAsync();
         var sourceResult = await RunScenarioAsync(source);


### PR DESCRIPTION
Replaced trip details with group details page, updating all UI, bindings, and resource keys to use "group" terminology. Added new GroupPage for group overview, including balance summary, timeline, and quick actions. Improved localization, editing, archiving, and exporting functionality for groups. Introduced view models for person editing and consumption options.

## What
-

## Why
-

## How to verify
- [ ] tests updated/passed
- [ ] typecheck passed
- [ ] export format unchanged (or documented)

## Notes
-